### PR TITLE
Remove persistent login channel.

### DIFF
--- a/csharp/HOLMS.Platform/HOLMS.Platform/Application.Client/IApplicationClient.cs
+++ b/csharp/HOLMS.Platform/HOLMS.Platform/Application.Client/IApplicationClient.cs
@@ -70,7 +70,6 @@ namespace HOLMS.Application.Client {
         RoomUseStatusCalculatorSvc.RoomUseStatusCalculatorSvcClient RoomUseStatusCalculatorSvc { get; }
         SessionContext SC { get; }
         string ServerName { get; }
-        SessionSvc.SessionSvcClient SessionSvc { get; }
         SessionService SS { get; }
         StaffMsgSvc.StaffMsgSvcClient StaffMsgSvc { get; }
         StaffSvc.StaffSvcClient StaffSvc { get; }

--- a/csharp/HOLMS.Platform/HOLMS.Platform/Application.Client/MockApplicationClient.cs
+++ b/csharp/HOLMS.Platform/HOLMS.Platform/Application.Client/MockApplicationClient.cs
@@ -2,7 +2,6 @@
 using System.Threading.Tasks;
 using HOLMS.Types.Booking.RPC;
 using HOLMS.Types.CRM.RPC;
-using HOLMS.Types.Extensions.Support;
 using HOLMS.Types.IAM.RPC;
 using HOLMS.Types.Money.RPC;
 using HOLMS.Types.Operations.RPC;


### PR DESCRIPTION
Done to remove heartache caused by NAT drops, etc. by using a channel that
sits inactive for ~1hr between uses.