### PR TITLE
Add search by email endpoint to guest service

### DIFF
--- a/csharp/HOLMS.Platform/HOLMS.Platform/Types/out/GuestSvc.cs
+++ b/csharp/HOLMS.Platform/HOLMS.Platform/Types/out/GuestSvc.cs
@@ -30,26 +30,31 @@ namespace HOLMS.Types.CRM.RPC {
             "TWFueVJlcXVlc3QSMwoDaWRzGAEgAygLMiYuaG9sbXMudHlwZXMuY3JtLmd1",
             "ZXN0cy5HdWVzdEluZGljYXRvciJUChtHdWVzdFN2Y1ByZWZpeFNlYXJjaFJl",
             "cXVlc3QSGgoSZmFtaWx5X25hbWVfcHJlZml4GAEgASgJEhkKEWdpdmVuX25h",
-            "bWVfcHJlZml4GAIgASgJMqUECghHdWVzdFN2YxJOCgNBbGwSFi5nb29nbGUu",
-            "cHJvdG9idWYuRW1wdHkaLy5ob2xtcy50eXBlcy5jcm0ucnBjLkd1ZXN0U3Zj",
-            "TWFueUd1ZXN0c1Jlc3BvbnNlElAKB0dldEJ5SWQSJi5ob2xtcy50eXBlcy5j",
-            "cm0uZ3Vlc3RzLkd1ZXN0SW5kaWNhdG9yGh0uaG9sbXMudHlwZXMuY3JtLmd1",
-            "ZXN0cy5HdWVzdBJuCg5HZXRTZXZlcmFsQnlJZBIrLmhvbG1zLnR5cGVzLmNy",
-            "bS5ycGMuR3Vlc3RTdmNHZXRNYW55UmVxdWVzdBovLmhvbG1zLnR5cGVzLmNy",
-            "bS5ycGMuR3Vlc3RTdmNNYW55R3Vlc3RzUmVzcG9uc2USdwoSU2VhcmNoQnlO",
-            "YW1lUHJlZml4EjAuaG9sbXMudHlwZXMuY3JtLnJwYy5HdWVzdFN2Y1ByZWZp",
-            "eFNlYXJjaFJlcXVlc3QaLy5ob2xtcy50eXBlcy5jcm0ucnBjLkd1ZXN0U3Zj",
-            "TWFueUd1ZXN0c1Jlc3BvbnNlEkYKBkNyZWF0ZRIdLmhvbG1zLnR5cGVzLmNy",
-            "bS5ndWVzdHMuR3Vlc3QaHS5ob2xtcy50eXBlcy5jcm0uZ3Vlc3RzLkd1ZXN0",
-            "EkYKBlVwZGF0ZRIdLmhvbG1zLnR5cGVzLmNybS5ndWVzdHMuR3Vlc3QaHS5o",
-            "b2xtcy50eXBlcy5jcm0uZ3Vlc3RzLkd1ZXN0Qh9aB2NybS9ycGOqAhNIT0xN",
-            "Uy5UeXBlcy5DUk0uUlBDYgZwcm90bzM="));
+            "bWVfcHJlZml4GAIgASgJIjUKHEd1ZXN0U3ZjU2VhcmNoQnlFbWFpbFJlcXVl",
+            "c3QSFQoNZW1haWxfYWRkcmVzcxgBIAEoCTKhBQoIR3Vlc3RTdmMSTgoDQWxs",
+            "EhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5Gi8uaG9sbXMudHlwZXMuY3JtLnJw",
+            "Yy5HdWVzdFN2Y01hbnlHdWVzdHNSZXNwb25zZRJQCgdHZXRCeUlkEiYuaG9s",
+            "bXMudHlwZXMuY3JtLmd1ZXN0cy5HdWVzdEluZGljYXRvchodLmhvbG1zLnR5",
+            "cGVzLmNybS5ndWVzdHMuR3Vlc3QSbgoOR2V0U2V2ZXJhbEJ5SWQSKy5ob2xt",
+            "cy50eXBlcy5jcm0ucnBjLkd1ZXN0U3ZjR2V0TWFueVJlcXVlc3QaLy5ob2xt",
+            "cy50eXBlcy5jcm0ucnBjLkd1ZXN0U3ZjTWFueUd1ZXN0c1Jlc3BvbnNlEncK",
+            "ElNlYXJjaEJ5TmFtZVByZWZpeBIwLmhvbG1zLnR5cGVzLmNybS5ycGMuR3Vl",
+            "c3RTdmNQcmVmaXhTZWFyY2hSZXF1ZXN0Gi8uaG9sbXMudHlwZXMuY3JtLnJw",
+            "Yy5HdWVzdFN2Y01hbnlHdWVzdHNSZXNwb25zZRJ6ChRTZWFyY2hCeUVtYWls",
+            "QWRkcmVzcxIxLmhvbG1zLnR5cGVzLmNybS5ycGMuR3Vlc3RTdmNTZWFyY2hC",
+            "eUVtYWlsUmVxdWVzdBovLmhvbG1zLnR5cGVzLmNybS5ycGMuR3Vlc3RTdmNN",
+            "YW55R3Vlc3RzUmVzcG9uc2USRgoGQ3JlYXRlEh0uaG9sbXMudHlwZXMuY3Jt",
+            "Lmd1ZXN0cy5HdWVzdBodLmhvbG1zLnR5cGVzLmNybS5ndWVzdHMuR3Vlc3QS",
+            "RgoGVXBkYXRlEh0uaG9sbXMudHlwZXMuY3JtLmd1ZXN0cy5HdWVzdBodLmhv",
+            "bG1zLnR5cGVzLmNybS5ndWVzdHMuR3Vlc3RCH1oHY3JtL3JwY6oCE0hPTE1T",
+            "LlR5cGVzLkNSTS5SUENiBnByb3RvMw=="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::Google.Protobuf.WellKnownTypes.EmptyReflection.Descriptor, global::HOLMS.Types.CRM.Guests.GuestIndicatorReflection.Descriptor, global::HOLMS.Types.CRM.Guests.GuestReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {
             new pbr::GeneratedClrTypeInfo(typeof(global::HOLMS.Types.CRM.RPC.GuestSvcManyGuestsResponse), global::HOLMS.Types.CRM.RPC.GuestSvcManyGuestsResponse.Parser, new[]{ "Guests" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::HOLMS.Types.CRM.RPC.GuestSvcGetManyRequest), global::HOLMS.Types.CRM.RPC.GuestSvcGetManyRequest.Parser, new[]{ "Ids" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::HOLMS.Types.CRM.RPC.GuestSvcPrefixSearchRequest), global::HOLMS.Types.CRM.RPC.GuestSvcPrefixSearchRequest.Parser, new[]{ "FamilyNamePrefix", "GivenNamePrefix" }, null, null, null)
+            new pbr::GeneratedClrTypeInfo(typeof(global::HOLMS.Types.CRM.RPC.GuestSvcPrefixSearchRequest), global::HOLMS.Types.CRM.RPC.GuestSvcPrefixSearchRequest.Parser, new[]{ "FamilyNamePrefix", "GivenNamePrefix" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::HOLMS.Types.CRM.RPC.GuestSvcSearchByEmailRequest), global::HOLMS.Types.CRM.RPC.GuestSvcSearchByEmailRequest.Parser, new[]{ "EmailAddress" }, null, null, null)
           }));
     }
     #endregion
@@ -411,6 +416,123 @@ namespace HOLMS.Types.CRM.RPC {
           }
           case 18: {
             GivenNamePrefix = input.ReadString();
+            break;
+          }
+        }
+      }
+    }
+
+  }
+
+  public sealed partial class GuestSvcSearchByEmailRequest : pb::IMessage<GuestSvcSearchByEmailRequest> {
+    private static readonly pb::MessageParser<GuestSvcSearchByEmailRequest> _parser = new pb::MessageParser<GuestSvcSearchByEmailRequest>(() => new GuestSvcSearchByEmailRequest());
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public static pb::MessageParser<GuestSvcSearchByEmailRequest> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::HOLMS.Types.CRM.RPC.GuestSvcReflection.Descriptor.MessageTypes[3]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public GuestSvcSearchByEmailRequest() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public GuestSvcSearchByEmailRequest(GuestSvcSearchByEmailRequest other) : this() {
+      emailAddress_ = other.emailAddress_;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public GuestSvcSearchByEmailRequest Clone() {
+      return new GuestSvcSearchByEmailRequest(this);
+    }
+
+    /// <summary>Field number for the "email_address" field.</summary>
+    public const int EmailAddressFieldNumber = 1;
+    private string emailAddress_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public string EmailAddress {
+      get { return emailAddress_; }
+      set {
+        emailAddress_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override bool Equals(object other) {
+      return Equals(other as GuestSvcSearchByEmailRequest);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public bool Equals(GuestSvcSearchByEmailRequest other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (EmailAddress != other.EmailAddress) return false;
+      return true;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (EmailAddress.Length != 0) hash ^= EmailAddress.GetHashCode();
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void WriteTo(pb::CodedOutputStream output) {
+      if (EmailAddress.Length != 0) {
+        output.WriteRawTag(10);
+        output.WriteString(EmailAddress);
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public int CalculateSize() {
+      int size = 0;
+      if (EmailAddress.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(EmailAddress);
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void MergeFrom(GuestSvcSearchByEmailRequest other) {
+      if (other == null) {
+        return;
+      }
+      if (other.EmailAddress.Length != 0) {
+        EmailAddress = other.EmailAddress;
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void MergeFrom(pb::CodedInputStream input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            input.SkipLastField();
+            break;
+          case 10: {
+            EmailAddress = input.ReadString();
             break;
           }
         }

--- a/csharp/HOLMS.Platform/HOLMS.Platform/Types/out/GuestSvcGrpc.cs
+++ b/csharp/HOLMS.Platform/HOLMS.Platform/Types/out/GuestSvcGrpc.cs
@@ -18,6 +18,7 @@ namespace HOLMS.Types.CRM.RPC {
     static readonly Marshaller<global::HOLMS.Types.CRM.Guests.Guest> __Marshaller_Guest = Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::HOLMS.Types.CRM.Guests.Guest.Parser.ParseFrom);
     static readonly Marshaller<global::HOLMS.Types.CRM.RPC.GuestSvcGetManyRequest> __Marshaller_GuestSvcGetManyRequest = Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::HOLMS.Types.CRM.RPC.GuestSvcGetManyRequest.Parser.ParseFrom);
     static readonly Marshaller<global::HOLMS.Types.CRM.RPC.GuestSvcPrefixSearchRequest> __Marshaller_GuestSvcPrefixSearchRequest = Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::HOLMS.Types.CRM.RPC.GuestSvcPrefixSearchRequest.Parser.ParseFrom);
+    static readonly Marshaller<global::HOLMS.Types.CRM.RPC.GuestSvcSearchByEmailRequest> __Marshaller_GuestSvcSearchByEmailRequest = Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::HOLMS.Types.CRM.RPC.GuestSvcSearchByEmailRequest.Parser.ParseFrom);
 
     static readonly Method<global::Google.Protobuf.WellKnownTypes.Empty, global::HOLMS.Types.CRM.RPC.GuestSvcManyGuestsResponse> __Method_All = new Method<global::Google.Protobuf.WellKnownTypes.Empty, global::HOLMS.Types.CRM.RPC.GuestSvcManyGuestsResponse>(
         MethodType.Unary,
@@ -45,6 +46,13 @@ namespace HOLMS.Types.CRM.RPC {
         __ServiceName,
         "SearchByNamePrefix",
         __Marshaller_GuestSvcPrefixSearchRequest,
+        __Marshaller_GuestSvcManyGuestsResponse);
+
+    static readonly Method<global::HOLMS.Types.CRM.RPC.GuestSvcSearchByEmailRequest, global::HOLMS.Types.CRM.RPC.GuestSvcManyGuestsResponse> __Method_SearchByEmailAddress = new Method<global::HOLMS.Types.CRM.RPC.GuestSvcSearchByEmailRequest, global::HOLMS.Types.CRM.RPC.GuestSvcManyGuestsResponse>(
+        MethodType.Unary,
+        __ServiceName,
+        "SearchByEmailAddress",
+        __Marshaller_GuestSvcSearchByEmailRequest,
         __Marshaller_GuestSvcManyGuestsResponse);
 
     static readonly Method<global::HOLMS.Types.CRM.Guests.Guest, global::HOLMS.Types.CRM.Guests.Guest> __Method_Create = new Method<global::HOLMS.Types.CRM.Guests.Guest, global::HOLMS.Types.CRM.Guests.Guest>(
@@ -86,6 +94,11 @@ namespace HOLMS.Types.CRM.RPC {
       }
 
       public virtual global::System.Threading.Tasks.Task<global::HOLMS.Types.CRM.RPC.GuestSvcManyGuestsResponse> SearchByNamePrefix(global::HOLMS.Types.CRM.RPC.GuestSvcPrefixSearchRequest request, ServerCallContext context)
+      {
+        throw new RpcException(new Status(StatusCode.Unimplemented, ""));
+      }
+
+      public virtual global::System.Threading.Tasks.Task<global::HOLMS.Types.CRM.RPC.GuestSvcManyGuestsResponse> SearchByEmailAddress(global::HOLMS.Types.CRM.RPC.GuestSvcSearchByEmailRequest request, ServerCallContext context)
       {
         throw new RpcException(new Status(StatusCode.Unimplemented, ""));
       }
@@ -189,6 +202,22 @@ namespace HOLMS.Types.CRM.RPC {
       {
         return CallInvoker.AsyncUnaryCall(__Method_SearchByNamePrefix, null, options, request);
       }
+      public virtual global::HOLMS.Types.CRM.RPC.GuestSvcManyGuestsResponse SearchByEmailAddress(global::HOLMS.Types.CRM.RPC.GuestSvcSearchByEmailRequest request, Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken))
+      {
+        return SearchByEmailAddress(request, new CallOptions(headers, deadline, cancellationToken));
+      }
+      public virtual global::HOLMS.Types.CRM.RPC.GuestSvcManyGuestsResponse SearchByEmailAddress(global::HOLMS.Types.CRM.RPC.GuestSvcSearchByEmailRequest request, CallOptions options)
+      {
+        return CallInvoker.BlockingUnaryCall(__Method_SearchByEmailAddress, null, options, request);
+      }
+      public virtual AsyncUnaryCall<global::HOLMS.Types.CRM.RPC.GuestSvcManyGuestsResponse> SearchByEmailAddressAsync(global::HOLMS.Types.CRM.RPC.GuestSvcSearchByEmailRequest request, Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken))
+      {
+        return SearchByEmailAddressAsync(request, new CallOptions(headers, deadline, cancellationToken));
+      }
+      public virtual AsyncUnaryCall<global::HOLMS.Types.CRM.RPC.GuestSvcManyGuestsResponse> SearchByEmailAddressAsync(global::HOLMS.Types.CRM.RPC.GuestSvcSearchByEmailRequest request, CallOptions options)
+      {
+        return CallInvoker.AsyncUnaryCall(__Method_SearchByEmailAddress, null, options, request);
+      }
       public virtual global::HOLMS.Types.CRM.Guests.Guest Create(global::HOLMS.Types.CRM.Guests.Guest request, Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken))
       {
         return Create(request, new CallOptions(headers, deadline, cancellationToken));
@@ -235,6 +264,7 @@ namespace HOLMS.Types.CRM.RPC {
           .AddMethod(__Method_GetById, serviceImpl.GetById)
           .AddMethod(__Method_GetSeveralById, serviceImpl.GetSeveralById)
           .AddMethod(__Method_SearchByNamePrefix, serviceImpl.SearchByNamePrefix)
+          .AddMethod(__Method_SearchByEmailAddress, serviceImpl.SearchByEmailAddress)
           .AddMethod(__Method_Create, serviceImpl.Create)
           .AddMethod(__Method_Update, serviceImpl.Update).Build();
     }

--- a/proto/crm/rpc/guest_svc.proto
+++ b/proto/crm/rpc/guest_svc.proto
@@ -21,11 +21,16 @@ message GuestSvcPrefixSearchRequest {
 	string given_name_prefix = 2;
 }
 
+message GuestSvcSearchByEmailRequest {
+	string email_address = 1;
+}
+
 service GuestSvc {
 	rpc All(google.protobuf.Empty) returns (GuestSvcManyGuestsResponse);
 	rpc GetById (.holms.types.crm.guests.GuestIndicator) returns (.holms.types.crm.guests.Guest);
 	rpc GetSeveralById (GuestSvcGetManyRequest) returns (GuestSvcManyGuestsResponse);
 	rpc SearchByNamePrefix (GuestSvcPrefixSearchRequest) returns (GuestSvcManyGuestsResponse);
+	rpc SearchByEmailAddress (GuestSvcSearchByEmailRequest) returns (GuestSvcManyGuestsResponse);
 	rpc Create (.holms.types.crm.guests.Guest) returns (.holms.types.crm.guests.Guest);
 	rpc Update (.holms.types.crm.guests.Guest) returns (.holms.types.crm.guests.Guest);
 }


### PR DESCRIPTION
This adds the service endpoint for "search for all guests with a provided email address". The backing implementation will be in application.

The higher-level goal is to enable association of a quasi-anonymous "web booker" with a previous guest, based on their supplied email address.

[#133051095]