### PR TITLE
Adds current-or-terminal-occupied-room to dtos

### DIFF
--- a/csharp/HOLMS.Platform/HOLMS.Platform/Types/out/CompleteOpenReservation.cs
+++ b/csharp/HOLMS.Platform/HOLMS.Platform/Types/out/CompleteOpenReservation.cs
@@ -32,7 +32,7 @@ namespace HOLMS.Types.Booking.Reservations {
             "bxoWY3JtL2d1ZXN0cy9ndWVzdC5wcm90bxohc3VwcGx5L3Jvb21fdHlwZXMv",
             "cm9vbV90eXBlLnByb3RvGhpzdXBwbHkvcXVhbGlmaWNhdGlvbi5wcm90bxov",
             "b3BlcmF0aW9ucy9ob3VzZWtlZXBpbmcvaG91c2VrZWVwaW5nX3RpbWUucHJv",
-            "dG8aJW9wZXJhdGlvbnMvcm9vbXMvcm9vbV9pbmRpY2F0b3IucHJvdG8iwAcK",
+            "dG8aJW9wZXJhdGlvbnMvcm9vbXMvcm9vbV9pbmRpY2F0b3IucHJvdG8inAgK",
             "F0NvbXBsZXRlT3BlblJlc2VydmF0aW9uEkcKCWVudGl0eV9pZBgBIAEoCzI0",
             "LmhvbG1zLnR5cGVzLmJvb2tpbmcuaW5kaWNhdG9ycy5SZXNlcnZhdGlvbklu",
             "ZGljYXRvchISCgpib29raW5nX2lkGAIgASgJEkEKBXN0YXRlGAMgASgOMjIu",
@@ -51,15 +51,17 @@ namespace HOLMS.Types.Booking.Reservations {
             "cGVzLnByaW1pdGl2ZS5Nb25ldGFyeUFtb3VudBJRChJoa190aW1lX3ByZWZl",
             "cmVuY2UYDyABKAsyNS5ob2xtcy50eXBlcy5vcGVyYXRpb25zLmhvdXNla2Vl",
             "cGluZy5Ib3VzZWtlZXBpbmdUaW1lEiEKGXZlaGljbGVfcGxhdGVfaW5mb3Jt",
-            "YXRpb24YECABKAkSMAooY3VycmVudF9vcl90ZXJtaW5hbF9vY2N1cGllZF9y",
-            "b29tX251bWJlchgRIAEoCRJWCiFjdXJyZW50X29yX3Rlcm1pbmFsX29jY3Vw",
-            "aWVkX3Jvb20YEiABKAsyKy5ob2xtcy50eXBlcy5vcGVyYXRpb25zLnJvb21z",
-            "LlJvb21JbmRpY2F0b3JCOVoUYm9va2luZy9yZXNlcnZhdGlvbnOqAiBIT0xN",
-            "Uy5UeXBlcy5Cb29raW5nLlJlc2VydmF0aW9uc2IGcHJvdG8z"));
+            "YXRpb24YECABKAkSJAocY3VycmVudF9vY2N1cGllZF9yb29tX251bWJlchgR",
+            "IAEoCRJKChVjdXJyZW50X29jY3VwaWVkX3Jvb20YEiABKAsyKy5ob2xtcy50",
+            "eXBlcy5vcGVyYXRpb25zLnJvb21zLlJvb21JbmRpY2F0b3ISJQoddGVybWlu",
+            "YWxfb2NjdXBpZWRfcm9vbV9udW1iZXIYEyABKAkSSwoWdGVybWluYWxfb2Nj",
+            "dXBpZWRfcm9vbRgUIAEoCzIrLmhvbG1zLnR5cGVzLm9wZXJhdGlvbnMucm9v",
+            "bXMuUm9vbUluZGljYXRvckI5WhRib29raW5nL3Jlc2VydmF0aW9uc6oCIEhP",
+            "TE1TLlR5cGVzLkJvb2tpbmcuUmVzZXJ2YXRpb25zYgZwcm90bzM="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::HOLMS.Types.Primitive.MonetaryAmountReflection.Descriptor, global::HOLMS.Types.Primitive.PbInclusiveOpsdateRangeReflection.Descriptor, global::HOLMS.Types.Booking.Reservations.ReservationGuaranteeStatusReflection.Descriptor, global::HOLMS.Types.Booking.Indicators.ReservationIndicatorReflection.Descriptor, global::HOLMS.Types.Booking.Reservations.ReservationStateReflection.Descriptor, global::HOLMS.Types.CRM.Guests.GuestReflection.Descriptor, global::HOLMS.Types.Supply.RoomTypes.RoomTypeReflection.Descriptor, global::HOLMS.Types.Supply.QualificationReflection.Descriptor, global::HOLMS.Types.Operations.Housekeeping.HousekeepingTimeReflection.Descriptor, global::HOLMS.Types.Operations.Rooms.RoomIndicatorReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {
-            new pbr::GeneratedClrTypeInfo(typeof(global::HOLMS.Types.Booking.Reservations.CompleteOpenReservation), global::HOLMS.Types.Booking.Reservations.CompleteOpenReservation.Parser, new[]{ "EntityId", "BookingId", "State", "Guest", "DateRange", "NumberAdults", "NumberChildren", "RoomType", "AdditionalGuests", "Qualification", "TaxExempt", "GuaranteeStatus", "UnpaidGuaranteeBalance", "HkTimePreference", "VehiclePlateInformation", "CurrentOrTerminalOccupiedRoomNumber", "CurrentOrTerminalOccupiedRoom" }, null, null, null)
+            new pbr::GeneratedClrTypeInfo(typeof(global::HOLMS.Types.Booking.Reservations.CompleteOpenReservation), global::HOLMS.Types.Booking.Reservations.CompleteOpenReservation.Parser, new[]{ "EntityId", "BookingId", "State", "Guest", "DateRange", "NumberAdults", "NumberChildren", "RoomType", "AdditionalGuests", "Qualification", "TaxExempt", "GuaranteeStatus", "UnpaidGuaranteeBalance", "HkTimePreference", "VehiclePlateInformation", "CurrentOccupiedRoomNumber", "CurrentOccupiedRoom", "TerminalOccupiedRoomNumber", "TerminalOccupiedRoom" }, null, null, null)
           }));
     }
     #endregion
@@ -105,8 +107,10 @@ namespace HOLMS.Types.Booking.Reservations {
       UnpaidGuaranteeBalance = other.unpaidGuaranteeBalance_ != null ? other.UnpaidGuaranteeBalance.Clone() : null;
       HkTimePreference = other.hkTimePreference_ != null ? other.HkTimePreference.Clone() : null;
       vehiclePlateInformation_ = other.vehiclePlateInformation_;
-      currentOrTerminalOccupiedRoomNumber_ = other.currentOrTerminalOccupiedRoomNumber_;
-      CurrentOrTerminalOccupiedRoom = other.currentOrTerminalOccupiedRoom_ != null ? other.CurrentOrTerminalOccupiedRoom.Clone() : null;
+      currentOccupiedRoomNumber_ = other.currentOccupiedRoomNumber_;
+      CurrentOccupiedRoom = other.currentOccupiedRoom_ != null ? other.CurrentOccupiedRoom.Clone() : null;
+      terminalOccupiedRoomNumber_ = other.terminalOccupiedRoomNumber_;
+      TerminalOccupiedRoom = other.terminalOccupiedRoom_ != null ? other.TerminalOccupiedRoom.Clone() : null;
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -278,25 +282,47 @@ namespace HOLMS.Types.Booking.Reservations {
       }
     }
 
-    /// <summary>Field number for the "current_or_terminal_occupied_room_number" field.</summary>
-    public const int CurrentOrTerminalOccupiedRoomNumberFieldNumber = 17;
-    private string currentOrTerminalOccupiedRoomNumber_ = "";
+    /// <summary>Field number for the "current_occupied_room_number" field.</summary>
+    public const int CurrentOccupiedRoomNumberFieldNumber = 17;
+    private string currentOccupiedRoomNumber_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public string CurrentOrTerminalOccupiedRoomNumber {
-      get { return currentOrTerminalOccupiedRoomNumber_; }
+    public string CurrentOccupiedRoomNumber {
+      get { return currentOccupiedRoomNumber_; }
       set {
-        currentOrTerminalOccupiedRoomNumber_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        currentOccupiedRoomNumber_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
-    /// <summary>Field number for the "current_or_terminal_occupied_room" field.</summary>
-    public const int CurrentOrTerminalOccupiedRoomFieldNumber = 18;
-    private global::HOLMS.Types.Operations.Rooms.RoomIndicator currentOrTerminalOccupiedRoom_;
+    /// <summary>Field number for the "current_occupied_room" field.</summary>
+    public const int CurrentOccupiedRoomFieldNumber = 18;
+    private global::HOLMS.Types.Operations.Rooms.RoomIndicator currentOccupiedRoom_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::HOLMS.Types.Operations.Rooms.RoomIndicator CurrentOrTerminalOccupiedRoom {
-      get { return currentOrTerminalOccupiedRoom_; }
+    public global::HOLMS.Types.Operations.Rooms.RoomIndicator CurrentOccupiedRoom {
+      get { return currentOccupiedRoom_; }
       set {
-        currentOrTerminalOccupiedRoom_ = value;
+        currentOccupiedRoom_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "terminal_occupied_room_number" field.</summary>
+    public const int TerminalOccupiedRoomNumberFieldNumber = 19;
+    private string terminalOccupiedRoomNumber_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public string TerminalOccupiedRoomNumber {
+      get { return terminalOccupiedRoomNumber_; }
+      set {
+        terminalOccupiedRoomNumber_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "terminal_occupied_room" field.</summary>
+    public const int TerminalOccupiedRoomFieldNumber = 20;
+    private global::HOLMS.Types.Operations.Rooms.RoomIndicator terminalOccupiedRoom_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public global::HOLMS.Types.Operations.Rooms.RoomIndicator TerminalOccupiedRoom {
+      get { return terminalOccupiedRoom_; }
+      set {
+        terminalOccupiedRoom_ = value;
       }
     }
 
@@ -328,8 +354,10 @@ namespace HOLMS.Types.Booking.Reservations {
       if (!object.Equals(UnpaidGuaranteeBalance, other.UnpaidGuaranteeBalance)) return false;
       if (!object.Equals(HkTimePreference, other.HkTimePreference)) return false;
       if (VehiclePlateInformation != other.VehiclePlateInformation) return false;
-      if (CurrentOrTerminalOccupiedRoomNumber != other.CurrentOrTerminalOccupiedRoomNumber) return false;
-      if (!object.Equals(CurrentOrTerminalOccupiedRoom, other.CurrentOrTerminalOccupiedRoom)) return false;
+      if (CurrentOccupiedRoomNumber != other.CurrentOccupiedRoomNumber) return false;
+      if (!object.Equals(CurrentOccupiedRoom, other.CurrentOccupiedRoom)) return false;
+      if (TerminalOccupiedRoomNumber != other.TerminalOccupiedRoomNumber) return false;
+      if (!object.Equals(TerminalOccupiedRoom, other.TerminalOccupiedRoom)) return false;
       return true;
     }
 
@@ -351,8 +379,10 @@ namespace HOLMS.Types.Booking.Reservations {
       if (unpaidGuaranteeBalance_ != null) hash ^= UnpaidGuaranteeBalance.GetHashCode();
       if (hkTimePreference_ != null) hash ^= HkTimePreference.GetHashCode();
       if (VehiclePlateInformation.Length != 0) hash ^= VehiclePlateInformation.GetHashCode();
-      if (CurrentOrTerminalOccupiedRoomNumber.Length != 0) hash ^= CurrentOrTerminalOccupiedRoomNumber.GetHashCode();
-      if (currentOrTerminalOccupiedRoom_ != null) hash ^= CurrentOrTerminalOccupiedRoom.GetHashCode();
+      if (CurrentOccupiedRoomNumber.Length != 0) hash ^= CurrentOccupiedRoomNumber.GetHashCode();
+      if (currentOccupiedRoom_ != null) hash ^= CurrentOccupiedRoom.GetHashCode();
+      if (TerminalOccupiedRoomNumber.Length != 0) hash ^= TerminalOccupiedRoomNumber.GetHashCode();
+      if (terminalOccupiedRoom_ != null) hash ^= TerminalOccupiedRoom.GetHashCode();
       return hash;
     }
 
@@ -420,13 +450,21 @@ namespace HOLMS.Types.Booking.Reservations {
         output.WriteRawTag(130, 1);
         output.WriteString(VehiclePlateInformation);
       }
-      if (CurrentOrTerminalOccupiedRoomNumber.Length != 0) {
+      if (CurrentOccupiedRoomNumber.Length != 0) {
         output.WriteRawTag(138, 1);
-        output.WriteString(CurrentOrTerminalOccupiedRoomNumber);
+        output.WriteString(CurrentOccupiedRoomNumber);
       }
-      if (currentOrTerminalOccupiedRoom_ != null) {
+      if (currentOccupiedRoom_ != null) {
         output.WriteRawTag(146, 1);
-        output.WriteMessage(CurrentOrTerminalOccupiedRoom);
+        output.WriteMessage(CurrentOccupiedRoom);
+      }
+      if (TerminalOccupiedRoomNumber.Length != 0) {
+        output.WriteRawTag(154, 1);
+        output.WriteString(TerminalOccupiedRoomNumber);
+      }
+      if (terminalOccupiedRoom_ != null) {
+        output.WriteRawTag(162, 1);
+        output.WriteMessage(TerminalOccupiedRoom);
       }
     }
 
@@ -476,11 +514,17 @@ namespace HOLMS.Types.Booking.Reservations {
       if (VehiclePlateInformation.Length != 0) {
         size += 2 + pb::CodedOutputStream.ComputeStringSize(VehiclePlateInformation);
       }
-      if (CurrentOrTerminalOccupiedRoomNumber.Length != 0) {
-        size += 2 + pb::CodedOutputStream.ComputeStringSize(CurrentOrTerminalOccupiedRoomNumber);
+      if (CurrentOccupiedRoomNumber.Length != 0) {
+        size += 2 + pb::CodedOutputStream.ComputeStringSize(CurrentOccupiedRoomNumber);
       }
-      if (currentOrTerminalOccupiedRoom_ != null) {
-        size += 2 + pb::CodedOutputStream.ComputeMessageSize(CurrentOrTerminalOccupiedRoom);
+      if (currentOccupiedRoom_ != null) {
+        size += 2 + pb::CodedOutputStream.ComputeMessageSize(CurrentOccupiedRoom);
+      }
+      if (TerminalOccupiedRoomNumber.Length != 0) {
+        size += 2 + pb::CodedOutputStream.ComputeStringSize(TerminalOccupiedRoomNumber);
+      }
+      if (terminalOccupiedRoom_ != null) {
+        size += 2 + pb::CodedOutputStream.ComputeMessageSize(TerminalOccupiedRoom);
       }
       return size;
     }
@@ -554,14 +598,23 @@ namespace HOLMS.Types.Booking.Reservations {
       if (other.VehiclePlateInformation.Length != 0) {
         VehiclePlateInformation = other.VehiclePlateInformation;
       }
-      if (other.CurrentOrTerminalOccupiedRoomNumber.Length != 0) {
-        CurrentOrTerminalOccupiedRoomNumber = other.CurrentOrTerminalOccupiedRoomNumber;
+      if (other.CurrentOccupiedRoomNumber.Length != 0) {
+        CurrentOccupiedRoomNumber = other.CurrentOccupiedRoomNumber;
       }
-      if (other.currentOrTerminalOccupiedRoom_ != null) {
-        if (currentOrTerminalOccupiedRoom_ == null) {
-          currentOrTerminalOccupiedRoom_ = new global::HOLMS.Types.Operations.Rooms.RoomIndicator();
+      if (other.currentOccupiedRoom_ != null) {
+        if (currentOccupiedRoom_ == null) {
+          currentOccupiedRoom_ = new global::HOLMS.Types.Operations.Rooms.RoomIndicator();
         }
-        CurrentOrTerminalOccupiedRoom.MergeFrom(other.CurrentOrTerminalOccupiedRoom);
+        CurrentOccupiedRoom.MergeFrom(other.CurrentOccupiedRoom);
+      }
+      if (other.TerminalOccupiedRoomNumber.Length != 0) {
+        TerminalOccupiedRoomNumber = other.TerminalOccupiedRoomNumber;
+      }
+      if (other.terminalOccupiedRoom_ != null) {
+        if (terminalOccupiedRoom_ == null) {
+          terminalOccupiedRoom_ = new global::HOLMS.Types.Operations.Rooms.RoomIndicator();
+        }
+        TerminalOccupiedRoom.MergeFrom(other.TerminalOccupiedRoom);
       }
     }
 
@@ -655,14 +708,25 @@ namespace HOLMS.Types.Booking.Reservations {
             break;
           }
           case 138: {
-            CurrentOrTerminalOccupiedRoomNumber = input.ReadString();
+            CurrentOccupiedRoomNumber = input.ReadString();
             break;
           }
           case 146: {
-            if (currentOrTerminalOccupiedRoom_ == null) {
-              currentOrTerminalOccupiedRoom_ = new global::HOLMS.Types.Operations.Rooms.RoomIndicator();
+            if (currentOccupiedRoom_ == null) {
+              currentOccupiedRoom_ = new global::HOLMS.Types.Operations.Rooms.RoomIndicator();
             }
-            input.ReadMessage(currentOrTerminalOccupiedRoom_);
+            input.ReadMessage(currentOccupiedRoom_);
+            break;
+          }
+          case 154: {
+            TerminalOccupiedRoomNumber = input.ReadString();
+            break;
+          }
+          case 162: {
+            if (terminalOccupiedRoom_ == null) {
+              terminalOccupiedRoom_ = new global::HOLMS.Types.Operations.Rooms.RoomIndicator();
+            }
+            input.ReadMessage(terminalOccupiedRoom_);
             break;
           }
         }

--- a/csharp/HOLMS.Platform/HOLMS.Platform/Types/out/CompleteOpenReservation.cs
+++ b/csharp/HOLMS.Platform/HOLMS.Platform/Types/out/CompleteOpenReservation.cs
@@ -32,30 +32,34 @@ namespace HOLMS.Types.Booking.Reservations {
             "bxoWY3JtL2d1ZXN0cy9ndWVzdC5wcm90bxohc3VwcGx5L3Jvb21fdHlwZXMv",
             "cm9vbV90eXBlLnByb3RvGhpzdXBwbHkvcXVhbGlmaWNhdGlvbi5wcm90bxov",
             "b3BlcmF0aW9ucy9ob3VzZWtlZXBpbmcvaG91c2VrZWVwaW5nX3RpbWUucHJv",
-            "dG8itgYKF0NvbXBsZXRlT3BlblJlc2VydmF0aW9uEkcKCWVudGl0eV9pZBgB",
-            "IAEoCzI0LmhvbG1zLnR5cGVzLmJvb2tpbmcuaW5kaWNhdG9ycy5SZXNlcnZh",
-            "dGlvbkluZGljYXRvchISCgpib29raW5nX2lkGAIgASgJEkEKBXN0YXRlGAMg",
-            "ASgOMjIuaG9sbXMudHlwZXMuYm9va2luZy5yZXNlcnZhdGlvbnMuUmVzZXJ2",
-            "YXRpb25TdGF0ZRIsCgVndWVzdBgEIAEoCzIdLmhvbG1zLnR5cGVzLmNybS5n",
-            "dWVzdHMuR3Vlc3QSQgoKZGF0ZV9yYW5nZRgFIAEoCzIuLmhvbG1zLnR5cGVz",
-            "LnByaW1pdGl2ZS5QYkluY2x1c2l2ZU9wc2RhdGVSYW5nZRIVCg1udW1iZXJf",
-            "YWR1bHRzGAYgASgFEhcKD251bWJlcl9jaGlsZHJlbhgHIAEoBRI6Cglyb29t",
-            "X3R5cGUYCCABKAsyJy5ob2xtcy50eXBlcy5zdXBwbHkucm9vbV90eXBlcy5S",
-            "b29tVHlwZRI4ChFhZGRpdGlvbmFsX2d1ZXN0cxgJIAMoCzIdLmhvbG1zLnR5",
-            "cGVzLmNybS5ndWVzdHMuR3Vlc3QSOAoNcXVhbGlmaWNhdGlvbhgKIAEoCzIh",
-            "LmhvbG1zLnR5cGVzLnN1cHBseS5RdWFsaWZpY2F0aW9uEhIKCnRheF9leGVt",
-            "cHQYCyABKAgSVgoQZ3VhcmFudGVlX3N0YXR1cxgMIAEoDjI8LmhvbG1zLnR5",
-            "cGVzLmJvb2tpbmcucmVzZXJ2YXRpb25zLlJlc2VydmF0aW9uR3VhcmFudGVl",
-            "U3RhdHVzEkcKGHVucGFpZF9ndWFyYW50ZWVfYmFsYW5jZRgNIAEoCzIlLmhv",
-            "bG1zLnR5cGVzLnByaW1pdGl2ZS5Nb25ldGFyeUFtb3VudBJRChJoa190aW1l",
-            "X3ByZWZlcmVuY2UYDyABKAsyNS5ob2xtcy50eXBlcy5vcGVyYXRpb25zLmhv",
-            "dXNla2VlcGluZy5Ib3VzZWtlZXBpbmdUaW1lEiEKGXZlaGljbGVfcGxhdGVf",
-            "aW5mb3JtYXRpb24YECABKAlCOVoUYm9va2luZy9yZXNlcnZhdGlvbnOqAiBI",
-            "T0xNUy5UeXBlcy5Cb29raW5nLlJlc2VydmF0aW9uc2IGcHJvdG8z"));
+            "dG8aJW9wZXJhdGlvbnMvcm9vbXMvcm9vbV9pbmRpY2F0b3IucHJvdG8iwAcK",
+            "F0NvbXBsZXRlT3BlblJlc2VydmF0aW9uEkcKCWVudGl0eV9pZBgBIAEoCzI0",
+            "LmhvbG1zLnR5cGVzLmJvb2tpbmcuaW5kaWNhdG9ycy5SZXNlcnZhdGlvbklu",
+            "ZGljYXRvchISCgpib29raW5nX2lkGAIgASgJEkEKBXN0YXRlGAMgASgOMjIu",
+            "aG9sbXMudHlwZXMuYm9va2luZy5yZXNlcnZhdGlvbnMuUmVzZXJ2YXRpb25T",
+            "dGF0ZRIsCgVndWVzdBgEIAEoCzIdLmhvbG1zLnR5cGVzLmNybS5ndWVzdHMu",
+            "R3Vlc3QSQgoKZGF0ZV9yYW5nZRgFIAEoCzIuLmhvbG1zLnR5cGVzLnByaW1p",
+            "dGl2ZS5QYkluY2x1c2l2ZU9wc2RhdGVSYW5nZRIVCg1udW1iZXJfYWR1bHRz",
+            "GAYgASgFEhcKD251bWJlcl9jaGlsZHJlbhgHIAEoBRI6Cglyb29tX3R5cGUY",
+            "CCABKAsyJy5ob2xtcy50eXBlcy5zdXBwbHkucm9vbV90eXBlcy5Sb29tVHlw",
+            "ZRI4ChFhZGRpdGlvbmFsX2d1ZXN0cxgJIAMoCzIdLmhvbG1zLnR5cGVzLmNy",
+            "bS5ndWVzdHMuR3Vlc3QSOAoNcXVhbGlmaWNhdGlvbhgKIAEoCzIhLmhvbG1z",
+            "LnR5cGVzLnN1cHBseS5RdWFsaWZpY2F0aW9uEhIKCnRheF9leGVtcHQYCyAB",
+            "KAgSVgoQZ3VhcmFudGVlX3N0YXR1cxgMIAEoDjI8LmhvbG1zLnR5cGVzLmJv",
+            "b2tpbmcucmVzZXJ2YXRpb25zLlJlc2VydmF0aW9uR3VhcmFudGVlU3RhdHVz",
+            "EkcKGHVucGFpZF9ndWFyYW50ZWVfYmFsYW5jZRgNIAEoCzIlLmhvbG1zLnR5",
+            "cGVzLnByaW1pdGl2ZS5Nb25ldGFyeUFtb3VudBJRChJoa190aW1lX3ByZWZl",
+            "cmVuY2UYDyABKAsyNS5ob2xtcy50eXBlcy5vcGVyYXRpb25zLmhvdXNla2Vl",
+            "cGluZy5Ib3VzZWtlZXBpbmdUaW1lEiEKGXZlaGljbGVfcGxhdGVfaW5mb3Jt",
+            "YXRpb24YECABKAkSMAooY3VycmVudF9vcl90ZXJtaW5hbF9vY2N1cGllZF9y",
+            "b29tX251bWJlchgRIAEoCRJWCiFjdXJyZW50X29yX3Rlcm1pbmFsX29jY3Vw",
+            "aWVkX3Jvb20YEiABKAsyKy5ob2xtcy50eXBlcy5vcGVyYXRpb25zLnJvb21z",
+            "LlJvb21JbmRpY2F0b3JCOVoUYm9va2luZy9yZXNlcnZhdGlvbnOqAiBIT0xN",
+            "Uy5UeXBlcy5Cb29raW5nLlJlc2VydmF0aW9uc2IGcHJvdG8z"));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
-          new pbr::FileDescriptor[] { global::HOLMS.Types.Primitive.MonetaryAmountReflection.Descriptor, global::HOLMS.Types.Primitive.PbInclusiveOpsdateRangeReflection.Descriptor, global::HOLMS.Types.Booking.Reservations.ReservationGuaranteeStatusReflection.Descriptor, global::HOLMS.Types.Booking.Indicators.ReservationIndicatorReflection.Descriptor, global::HOLMS.Types.Booking.Reservations.ReservationStateReflection.Descriptor, global::HOLMS.Types.CRM.Guests.GuestReflection.Descriptor, global::HOLMS.Types.Supply.RoomTypes.RoomTypeReflection.Descriptor, global::HOLMS.Types.Supply.QualificationReflection.Descriptor, global::HOLMS.Types.Operations.Housekeeping.HousekeepingTimeReflection.Descriptor, },
+          new pbr::FileDescriptor[] { global::HOLMS.Types.Primitive.MonetaryAmountReflection.Descriptor, global::HOLMS.Types.Primitive.PbInclusiveOpsdateRangeReflection.Descriptor, global::HOLMS.Types.Booking.Reservations.ReservationGuaranteeStatusReflection.Descriptor, global::HOLMS.Types.Booking.Indicators.ReservationIndicatorReflection.Descriptor, global::HOLMS.Types.Booking.Reservations.ReservationStateReflection.Descriptor, global::HOLMS.Types.CRM.Guests.GuestReflection.Descriptor, global::HOLMS.Types.Supply.RoomTypes.RoomTypeReflection.Descriptor, global::HOLMS.Types.Supply.QualificationReflection.Descriptor, global::HOLMS.Types.Operations.Housekeeping.HousekeepingTimeReflection.Descriptor, global::HOLMS.Types.Operations.Rooms.RoomIndicatorReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {
-            new pbr::GeneratedClrTypeInfo(typeof(global::HOLMS.Types.Booking.Reservations.CompleteOpenReservation), global::HOLMS.Types.Booking.Reservations.CompleteOpenReservation.Parser, new[]{ "EntityId", "BookingId", "State", "Guest", "DateRange", "NumberAdults", "NumberChildren", "RoomType", "AdditionalGuests", "Qualification", "TaxExempt", "GuaranteeStatus", "UnpaidGuaranteeBalance", "HkTimePreference", "VehiclePlateInformation" }, null, null, null)
+            new pbr::GeneratedClrTypeInfo(typeof(global::HOLMS.Types.Booking.Reservations.CompleteOpenReservation), global::HOLMS.Types.Booking.Reservations.CompleteOpenReservation.Parser, new[]{ "EntityId", "BookingId", "State", "Guest", "DateRange", "NumberAdults", "NumberChildren", "RoomType", "AdditionalGuests", "Qualification", "TaxExempt", "GuaranteeStatus", "UnpaidGuaranteeBalance", "HkTimePreference", "VehiclePlateInformation", "CurrentOrTerminalOccupiedRoomNumber", "CurrentOrTerminalOccupiedRoom" }, null, null, null)
           }));
     }
     #endregion
@@ -101,6 +105,8 @@ namespace HOLMS.Types.Booking.Reservations {
       UnpaidGuaranteeBalance = other.unpaidGuaranteeBalance_ != null ? other.UnpaidGuaranteeBalance.Clone() : null;
       HkTimePreference = other.hkTimePreference_ != null ? other.HkTimePreference.Clone() : null;
       vehiclePlateInformation_ = other.vehiclePlateInformation_;
+      currentOrTerminalOccupiedRoomNumber_ = other.currentOrTerminalOccupiedRoomNumber_;
+      CurrentOrTerminalOccupiedRoom = other.currentOrTerminalOccupiedRoom_ != null ? other.CurrentOrTerminalOccupiedRoom.Clone() : null;
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -272,6 +278,28 @@ namespace HOLMS.Types.Booking.Reservations {
       }
     }
 
+    /// <summary>Field number for the "current_or_terminal_occupied_room_number" field.</summary>
+    public const int CurrentOrTerminalOccupiedRoomNumberFieldNumber = 17;
+    private string currentOrTerminalOccupiedRoomNumber_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public string CurrentOrTerminalOccupiedRoomNumber {
+      get { return currentOrTerminalOccupiedRoomNumber_; }
+      set {
+        currentOrTerminalOccupiedRoomNumber_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "current_or_terminal_occupied_room" field.</summary>
+    public const int CurrentOrTerminalOccupiedRoomFieldNumber = 18;
+    private global::HOLMS.Types.Operations.Rooms.RoomIndicator currentOrTerminalOccupiedRoom_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public global::HOLMS.Types.Operations.Rooms.RoomIndicator CurrentOrTerminalOccupiedRoom {
+      get { return currentOrTerminalOccupiedRoom_; }
+      set {
+        currentOrTerminalOccupiedRoom_ = value;
+      }
+    }
+
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as CompleteOpenReservation);
@@ -300,6 +328,8 @@ namespace HOLMS.Types.Booking.Reservations {
       if (!object.Equals(UnpaidGuaranteeBalance, other.UnpaidGuaranteeBalance)) return false;
       if (!object.Equals(HkTimePreference, other.HkTimePreference)) return false;
       if (VehiclePlateInformation != other.VehiclePlateInformation) return false;
+      if (CurrentOrTerminalOccupiedRoomNumber != other.CurrentOrTerminalOccupiedRoomNumber) return false;
+      if (!object.Equals(CurrentOrTerminalOccupiedRoom, other.CurrentOrTerminalOccupiedRoom)) return false;
       return true;
     }
 
@@ -321,6 +351,8 @@ namespace HOLMS.Types.Booking.Reservations {
       if (unpaidGuaranteeBalance_ != null) hash ^= UnpaidGuaranteeBalance.GetHashCode();
       if (hkTimePreference_ != null) hash ^= HkTimePreference.GetHashCode();
       if (VehiclePlateInformation.Length != 0) hash ^= VehiclePlateInformation.GetHashCode();
+      if (CurrentOrTerminalOccupiedRoomNumber.Length != 0) hash ^= CurrentOrTerminalOccupiedRoomNumber.GetHashCode();
+      if (currentOrTerminalOccupiedRoom_ != null) hash ^= CurrentOrTerminalOccupiedRoom.GetHashCode();
       return hash;
     }
 
@@ -388,6 +420,14 @@ namespace HOLMS.Types.Booking.Reservations {
         output.WriteRawTag(130, 1);
         output.WriteString(VehiclePlateInformation);
       }
+      if (CurrentOrTerminalOccupiedRoomNumber.Length != 0) {
+        output.WriteRawTag(138, 1);
+        output.WriteString(CurrentOrTerminalOccupiedRoomNumber);
+      }
+      if (currentOrTerminalOccupiedRoom_ != null) {
+        output.WriteRawTag(146, 1);
+        output.WriteMessage(CurrentOrTerminalOccupiedRoom);
+      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -435,6 +475,12 @@ namespace HOLMS.Types.Booking.Reservations {
       }
       if (VehiclePlateInformation.Length != 0) {
         size += 2 + pb::CodedOutputStream.ComputeStringSize(VehiclePlateInformation);
+      }
+      if (CurrentOrTerminalOccupiedRoomNumber.Length != 0) {
+        size += 2 + pb::CodedOutputStream.ComputeStringSize(CurrentOrTerminalOccupiedRoomNumber);
+      }
+      if (currentOrTerminalOccupiedRoom_ != null) {
+        size += 2 + pb::CodedOutputStream.ComputeMessageSize(CurrentOrTerminalOccupiedRoom);
       }
       return size;
     }
@@ -507,6 +553,15 @@ namespace HOLMS.Types.Booking.Reservations {
       }
       if (other.VehiclePlateInformation.Length != 0) {
         VehiclePlateInformation = other.VehiclePlateInformation;
+      }
+      if (other.CurrentOrTerminalOccupiedRoomNumber.Length != 0) {
+        CurrentOrTerminalOccupiedRoomNumber = other.CurrentOrTerminalOccupiedRoomNumber;
+      }
+      if (other.currentOrTerminalOccupiedRoom_ != null) {
+        if (currentOrTerminalOccupiedRoom_ == null) {
+          currentOrTerminalOccupiedRoom_ = new global::HOLMS.Types.Operations.Rooms.RoomIndicator();
+        }
+        CurrentOrTerminalOccupiedRoom.MergeFrom(other.CurrentOrTerminalOccupiedRoom);
       }
     }
 
@@ -597,6 +652,17 @@ namespace HOLMS.Types.Booking.Reservations {
           }
           case 130: {
             VehiclePlateInformation = input.ReadString();
+            break;
+          }
+          case 138: {
+            CurrentOrTerminalOccupiedRoomNumber = input.ReadString();
+            break;
+          }
+          case 146: {
+            if (currentOrTerminalOccupiedRoom_ == null) {
+              currentOrTerminalOccupiedRoom_ = new global::HOLMS.Types.Operations.Rooms.RoomIndicator();
+            }
+            input.ReadMessage(currentOrTerminalOccupiedRoom_);
             break;
           }
         }

--- a/csharp/HOLMS.Platform/HOLMS.Platform/Types/out/ReservationSummary.cs
+++ b/csharp/HOLMS.Platform/HOLMS.Platform/Types/out/ReservationSummary.cs
@@ -32,7 +32,7 @@ namespace HOLMS.Types.Booking.Reservations {
             "dHlwZXMvcm9vbV90eXBlLnByb3RvGhtpYW0vdGVuYW5jeV9pbmRpY2F0b3Iu",
             "cHJvdG8aMnRlbmFuY3lfY29uZmlnL2luZGljYXRvcnMvcHJvcGVydHlfaW5k",
             "aWNhdG9yLnByb3RvGiVvcGVyYXRpb25zL3Jvb21zL3Jvb21faW5kaWNhdG9y",
-            "LnByb3RvIoEGChJSZXNlcnZhdGlvblN1bW1hcnkSRwoJZW50aXR5X2lkGAEg",
+            "LnByb3RvIt0GChJSZXNlcnZhdGlvblN1bW1hcnkSRwoJZW50aXR5X2lkGAEg",
             "ASgLMjQuaG9sbXMudHlwZXMuYm9va2luZy5pbmRpY2F0b3JzLlJlc2VydmF0",
             "aW9uSW5kaWNhdG9yEhIKCmJvb2tpbmdfaWQYAiABKAkSQQoFc3RhdGUYAyAB",
             "KA4yMi5ob2xtcy50eXBlcy5ib29raW5nLnJlc2VydmF0aW9ucy5SZXNlcnZh",
@@ -46,15 +46,17 @@ namespace HOLMS.Types.Booking.Reservations {
             "bmRpY2F0b3ISSgoIcHJvcGVydHkYCSABKAsyOC5ob2xtcy50eXBlcy50ZW5h",
             "bmN5X2NvbmZpZy5pbmRpY2F0b3JzLlByb3BlcnR5SW5kaWNhdG9yEhgKEGdy",
             "b3VwX2Jvb2tpbmdfaWQYCiABKAkSIQoZdmVoaWNsZV9wbGF0ZV9pbmZvcm1h",
-            "dGlvbhgLIAEoCRIwCihjdXJyZW50X29yX3Rlcm1pbmFsX29jY3VwaWVkX3Jv",
-            "b21fbnVtYmVyGAwgASgJElYKIWN1cnJlbnRfb3JfdGVybWluYWxfb2NjdXBp",
-            "ZWRfcm9vbRgNIAEoCzIrLmhvbG1zLnR5cGVzLm9wZXJhdGlvbnMucm9vbXMu",
-            "Um9vbUluZGljYXRvckI5WhRib29raW5nL3Jlc2VydmF0aW9uc6oCIEhPTE1T",
-            "LlR5cGVzLkJvb2tpbmcuUmVzZXJ2YXRpb25zYgZwcm90bzM="));
+            "dGlvbhgLIAEoCRIkChxjdXJyZW50X29jY3VwaWVkX3Jvb21fbnVtYmVyGAwg",
+            "ASgJEkoKFWN1cnJlbnRfb2NjdXBpZWRfcm9vbRgNIAEoCzIrLmhvbG1zLnR5",
+            "cGVzLm9wZXJhdGlvbnMucm9vbXMuUm9vbUluZGljYXRvchIlCh10ZXJtaW5h",
+            "bF9vY2N1cGllZF9yb29tX251bWJlchgOIAEoCRJLChZ0ZXJtaW5hbF9vY2N1",
+            "cGllZF9yb29tGA8gASgLMisuaG9sbXMudHlwZXMub3BlcmF0aW9ucy5yb29t",
+            "cy5Sb29tSW5kaWNhdG9yQjlaFGJvb2tpbmcvcmVzZXJ2YXRpb25zqgIgSE9M",
+            "TVMuVHlwZXMuQm9va2luZy5SZXNlcnZhdGlvbnNiBnByb3RvMw=="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::HOLMS.Types.Booking.Reservations.ReservationGuaranteeStatusReflection.Descriptor, global::HOLMS.Types.Booking.Indicators.ReservationIndicatorReflection.Descriptor, global::HOLMS.Types.Booking.Reservations.ReservationStateReflection.Descriptor, global::HOLMS.Types.CRM.Guests.GuestReflection.Descriptor, global::HOLMS.Types.Primitive.PbInclusiveOpsdateRangeReflection.Descriptor, global::HOLMS.Types.Supply.RoomTypes.RoomTypeReflection.Descriptor, global::HOLMS.Types.IAM.TenancyIndicatorReflection.Descriptor, global::HOLMS.Types.TenancyConfig.Indicators.PropertyIndicatorReflection.Descriptor, global::HOLMS.Types.Operations.Rooms.RoomIndicatorReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {
-            new pbr::GeneratedClrTypeInfo(typeof(global::HOLMS.Types.Booking.Reservations.ReservationSummary), global::HOLMS.Types.Booking.Reservations.ReservationSummary.Parser, new[]{ "EntityId", "BookingId", "State", "Guest", "DateRange", "RoomType", "GuaranteeStatus", "Tenancy", "Property", "GroupBookingId", "VehiclePlateInformation", "CurrentOrTerminalOccupiedRoomNumber", "CurrentOrTerminalOccupiedRoom" }, null, null, null)
+            new pbr::GeneratedClrTypeInfo(typeof(global::HOLMS.Types.Booking.Reservations.ReservationSummary), global::HOLMS.Types.Booking.Reservations.ReservationSummary.Parser, new[]{ "EntityId", "BookingId", "State", "Guest", "DateRange", "RoomType", "GuaranteeStatus", "Tenancy", "Property", "GroupBookingId", "VehiclePlateInformation", "CurrentOccupiedRoomNumber", "CurrentOccupiedRoom", "TerminalOccupiedRoomNumber", "TerminalOccupiedRoom" }, null, null, null)
           }));
     }
     #endregion
@@ -96,8 +98,10 @@ namespace HOLMS.Types.Booking.Reservations {
       Property = other.property_ != null ? other.Property.Clone() : null;
       groupBookingId_ = other.groupBookingId_;
       vehiclePlateInformation_ = other.vehiclePlateInformation_;
-      currentOrTerminalOccupiedRoomNumber_ = other.currentOrTerminalOccupiedRoomNumber_;
-      CurrentOrTerminalOccupiedRoom = other.currentOrTerminalOccupiedRoom_ != null ? other.CurrentOrTerminalOccupiedRoom.Clone() : null;
+      currentOccupiedRoomNumber_ = other.currentOccupiedRoomNumber_;
+      CurrentOccupiedRoom = other.currentOccupiedRoom_ != null ? other.CurrentOccupiedRoom.Clone() : null;
+      terminalOccupiedRoomNumber_ = other.terminalOccupiedRoomNumber_;
+      TerminalOccupiedRoom = other.terminalOccupiedRoom_ != null ? other.TerminalOccupiedRoom.Clone() : null;
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -226,25 +230,47 @@ namespace HOLMS.Types.Booking.Reservations {
       }
     }
 
-    /// <summary>Field number for the "current_or_terminal_occupied_room_number" field.</summary>
-    public const int CurrentOrTerminalOccupiedRoomNumberFieldNumber = 12;
-    private string currentOrTerminalOccupiedRoomNumber_ = "";
+    /// <summary>Field number for the "current_occupied_room_number" field.</summary>
+    public const int CurrentOccupiedRoomNumberFieldNumber = 12;
+    private string currentOccupiedRoomNumber_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public string CurrentOrTerminalOccupiedRoomNumber {
-      get { return currentOrTerminalOccupiedRoomNumber_; }
+    public string CurrentOccupiedRoomNumber {
+      get { return currentOccupiedRoomNumber_; }
       set {
-        currentOrTerminalOccupiedRoomNumber_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        currentOccupiedRoomNumber_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
-    /// <summary>Field number for the "current_or_terminal_occupied_room" field.</summary>
-    public const int CurrentOrTerminalOccupiedRoomFieldNumber = 13;
-    private global::HOLMS.Types.Operations.Rooms.RoomIndicator currentOrTerminalOccupiedRoom_;
+    /// <summary>Field number for the "current_occupied_room" field.</summary>
+    public const int CurrentOccupiedRoomFieldNumber = 13;
+    private global::HOLMS.Types.Operations.Rooms.RoomIndicator currentOccupiedRoom_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::HOLMS.Types.Operations.Rooms.RoomIndicator CurrentOrTerminalOccupiedRoom {
-      get { return currentOrTerminalOccupiedRoom_; }
+    public global::HOLMS.Types.Operations.Rooms.RoomIndicator CurrentOccupiedRoom {
+      get { return currentOccupiedRoom_; }
       set {
-        currentOrTerminalOccupiedRoom_ = value;
+        currentOccupiedRoom_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "terminal_occupied_room_number" field.</summary>
+    public const int TerminalOccupiedRoomNumberFieldNumber = 14;
+    private string terminalOccupiedRoomNumber_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public string TerminalOccupiedRoomNumber {
+      get { return terminalOccupiedRoomNumber_; }
+      set {
+        terminalOccupiedRoomNumber_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "terminal_occupied_room" field.</summary>
+    public const int TerminalOccupiedRoomFieldNumber = 15;
+    private global::HOLMS.Types.Operations.Rooms.RoomIndicator terminalOccupiedRoom_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public global::HOLMS.Types.Operations.Rooms.RoomIndicator TerminalOccupiedRoom {
+      get { return terminalOccupiedRoom_; }
+      set {
+        terminalOccupiedRoom_ = value;
       }
     }
 
@@ -272,8 +298,10 @@ namespace HOLMS.Types.Booking.Reservations {
       if (!object.Equals(Property, other.Property)) return false;
       if (GroupBookingId != other.GroupBookingId) return false;
       if (VehiclePlateInformation != other.VehiclePlateInformation) return false;
-      if (CurrentOrTerminalOccupiedRoomNumber != other.CurrentOrTerminalOccupiedRoomNumber) return false;
-      if (!object.Equals(CurrentOrTerminalOccupiedRoom, other.CurrentOrTerminalOccupiedRoom)) return false;
+      if (CurrentOccupiedRoomNumber != other.CurrentOccupiedRoomNumber) return false;
+      if (!object.Equals(CurrentOccupiedRoom, other.CurrentOccupiedRoom)) return false;
+      if (TerminalOccupiedRoomNumber != other.TerminalOccupiedRoomNumber) return false;
+      if (!object.Equals(TerminalOccupiedRoom, other.TerminalOccupiedRoom)) return false;
       return true;
     }
 
@@ -291,8 +319,10 @@ namespace HOLMS.Types.Booking.Reservations {
       if (property_ != null) hash ^= Property.GetHashCode();
       if (GroupBookingId.Length != 0) hash ^= GroupBookingId.GetHashCode();
       if (VehiclePlateInformation.Length != 0) hash ^= VehiclePlateInformation.GetHashCode();
-      if (CurrentOrTerminalOccupiedRoomNumber.Length != 0) hash ^= CurrentOrTerminalOccupiedRoomNumber.GetHashCode();
-      if (currentOrTerminalOccupiedRoom_ != null) hash ^= CurrentOrTerminalOccupiedRoom.GetHashCode();
+      if (CurrentOccupiedRoomNumber.Length != 0) hash ^= CurrentOccupiedRoomNumber.GetHashCode();
+      if (currentOccupiedRoom_ != null) hash ^= CurrentOccupiedRoom.GetHashCode();
+      if (TerminalOccupiedRoomNumber.Length != 0) hash ^= TerminalOccupiedRoomNumber.GetHashCode();
+      if (terminalOccupiedRoom_ != null) hash ^= TerminalOccupiedRoom.GetHashCode();
       return hash;
     }
 
@@ -347,13 +377,21 @@ namespace HOLMS.Types.Booking.Reservations {
         output.WriteRawTag(90);
         output.WriteString(VehiclePlateInformation);
       }
-      if (CurrentOrTerminalOccupiedRoomNumber.Length != 0) {
+      if (CurrentOccupiedRoomNumber.Length != 0) {
         output.WriteRawTag(98);
-        output.WriteString(CurrentOrTerminalOccupiedRoomNumber);
+        output.WriteString(CurrentOccupiedRoomNumber);
       }
-      if (currentOrTerminalOccupiedRoom_ != null) {
+      if (currentOccupiedRoom_ != null) {
         output.WriteRawTag(106);
-        output.WriteMessage(CurrentOrTerminalOccupiedRoom);
+        output.WriteMessage(CurrentOccupiedRoom);
+      }
+      if (TerminalOccupiedRoomNumber.Length != 0) {
+        output.WriteRawTag(114);
+        output.WriteString(TerminalOccupiedRoomNumber);
+      }
+      if (terminalOccupiedRoom_ != null) {
+        output.WriteRawTag(122);
+        output.WriteMessage(TerminalOccupiedRoom);
       }
     }
 
@@ -393,11 +431,17 @@ namespace HOLMS.Types.Booking.Reservations {
       if (VehiclePlateInformation.Length != 0) {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(VehiclePlateInformation);
       }
-      if (CurrentOrTerminalOccupiedRoomNumber.Length != 0) {
-        size += 1 + pb::CodedOutputStream.ComputeStringSize(CurrentOrTerminalOccupiedRoomNumber);
+      if (CurrentOccupiedRoomNumber.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(CurrentOccupiedRoomNumber);
       }
-      if (currentOrTerminalOccupiedRoom_ != null) {
-        size += 1 + pb::CodedOutputStream.ComputeMessageSize(CurrentOrTerminalOccupiedRoom);
+      if (currentOccupiedRoom_ != null) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(CurrentOccupiedRoom);
+      }
+      if (TerminalOccupiedRoomNumber.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(TerminalOccupiedRoomNumber);
+      }
+      if (terminalOccupiedRoom_ != null) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(TerminalOccupiedRoom);
       }
       return size;
     }
@@ -458,14 +502,23 @@ namespace HOLMS.Types.Booking.Reservations {
       if (other.VehiclePlateInformation.Length != 0) {
         VehiclePlateInformation = other.VehiclePlateInformation;
       }
-      if (other.CurrentOrTerminalOccupiedRoomNumber.Length != 0) {
-        CurrentOrTerminalOccupiedRoomNumber = other.CurrentOrTerminalOccupiedRoomNumber;
+      if (other.CurrentOccupiedRoomNumber.Length != 0) {
+        CurrentOccupiedRoomNumber = other.CurrentOccupiedRoomNumber;
       }
-      if (other.currentOrTerminalOccupiedRoom_ != null) {
-        if (currentOrTerminalOccupiedRoom_ == null) {
-          currentOrTerminalOccupiedRoom_ = new global::HOLMS.Types.Operations.Rooms.RoomIndicator();
+      if (other.currentOccupiedRoom_ != null) {
+        if (currentOccupiedRoom_ == null) {
+          currentOccupiedRoom_ = new global::HOLMS.Types.Operations.Rooms.RoomIndicator();
         }
-        CurrentOrTerminalOccupiedRoom.MergeFrom(other.CurrentOrTerminalOccupiedRoom);
+        CurrentOccupiedRoom.MergeFrom(other.CurrentOccupiedRoom);
+      }
+      if (other.TerminalOccupiedRoomNumber.Length != 0) {
+        TerminalOccupiedRoomNumber = other.TerminalOccupiedRoomNumber;
+      }
+      if (other.terminalOccupiedRoom_ != null) {
+        if (terminalOccupiedRoom_ == null) {
+          terminalOccupiedRoom_ = new global::HOLMS.Types.Operations.Rooms.RoomIndicator();
+        }
+        TerminalOccupiedRoom.MergeFrom(other.TerminalOccupiedRoom);
       }
     }
 
@@ -540,14 +593,25 @@ namespace HOLMS.Types.Booking.Reservations {
             break;
           }
           case 98: {
-            CurrentOrTerminalOccupiedRoomNumber = input.ReadString();
+            CurrentOccupiedRoomNumber = input.ReadString();
             break;
           }
           case 106: {
-            if (currentOrTerminalOccupiedRoom_ == null) {
-              currentOrTerminalOccupiedRoom_ = new global::HOLMS.Types.Operations.Rooms.RoomIndicator();
+            if (currentOccupiedRoom_ == null) {
+              currentOccupiedRoom_ = new global::HOLMS.Types.Operations.Rooms.RoomIndicator();
             }
-            input.ReadMessage(currentOrTerminalOccupiedRoom_);
+            input.ReadMessage(currentOccupiedRoom_);
+            break;
+          }
+          case 114: {
+            TerminalOccupiedRoomNumber = input.ReadString();
+            break;
+          }
+          case 122: {
+            if (terminalOccupiedRoom_ == null) {
+              terminalOccupiedRoom_ = new global::HOLMS.Types.Operations.Rooms.RoomIndicator();
+            }
+            input.ReadMessage(terminalOccupiedRoom_);
             break;
           }
         }

--- a/csharp/HOLMS.Platform/HOLMS.Platform/Types/out/ReservationSummary.cs
+++ b/csharp/HOLMS.Platform/HOLMS.Platform/Types/out/ReservationSummary.cs
@@ -31,26 +31,30 @@ namespace HOLMS.Types.Booking.Reservations {
             "Yl9pbmNsdXNpdmVfb3BzZGF0ZV9yYW5nZS5wcm90bxohc3VwcGx5L3Jvb21f",
             "dHlwZXMvcm9vbV90eXBlLnByb3RvGhtpYW0vdGVuYW5jeV9pbmRpY2F0b3Iu",
             "cHJvdG8aMnRlbmFuY3lfY29uZmlnL2luZGljYXRvcnMvcHJvcGVydHlfaW5k",
-            "aWNhdG9yLnByb3RvIvcEChJSZXNlcnZhdGlvblN1bW1hcnkSRwoJZW50aXR5",
-            "X2lkGAEgASgLMjQuaG9sbXMudHlwZXMuYm9va2luZy5pbmRpY2F0b3JzLlJl",
-            "c2VydmF0aW9uSW5kaWNhdG9yEhIKCmJvb2tpbmdfaWQYAiABKAkSQQoFc3Rh",
-            "dGUYAyABKA4yMi5ob2xtcy50eXBlcy5ib29raW5nLnJlc2VydmF0aW9ucy5S",
-            "ZXNlcnZhdGlvblN0YXRlEiwKBWd1ZXN0GAQgASgLMh0uaG9sbXMudHlwZXMu",
-            "Y3JtLmd1ZXN0cy5HdWVzdBJCCgpkYXRlX3JhbmdlGAUgASgLMi4uaG9sbXMu",
-            "dHlwZXMucHJpbWl0aXZlLlBiSW5jbHVzaXZlT3BzZGF0ZVJhbmdlEjoKCXJv",
-            "b21fdHlwZRgGIAEoCzInLmhvbG1zLnR5cGVzLnN1cHBseS5yb29tX3R5cGVz",
-            "LlJvb21UeXBlElYKEGd1YXJhbnRlZV9zdGF0dXMYByABKA4yPC5ob2xtcy50",
-            "eXBlcy5ib29raW5nLnJlc2VydmF0aW9ucy5SZXNlcnZhdGlvbkd1YXJhbnRl",
-            "ZVN0YXR1cxIyCgd0ZW5hbmN5GAggASgLMiEuaG9sbXMudHlwZXMuaWFtLlRl",
-            "bmFuY3lJbmRpY2F0b3ISSgoIcHJvcGVydHkYCSABKAsyOC5ob2xtcy50eXBl",
-            "cy50ZW5hbmN5X2NvbmZpZy5pbmRpY2F0b3JzLlByb3BlcnR5SW5kaWNhdG9y",
-            "EhgKEGdyb3VwX2Jvb2tpbmdfaWQYCiABKAkSIQoZdmVoaWNsZV9wbGF0ZV9p",
-            "bmZvcm1hdGlvbhgLIAEoCUI5WhRib29raW5nL3Jlc2VydmF0aW9uc6oCIEhP",
-            "TE1TLlR5cGVzLkJvb2tpbmcuUmVzZXJ2YXRpb25zYgZwcm90bzM="));
+            "aWNhdG9yLnByb3RvGiVvcGVyYXRpb25zL3Jvb21zL3Jvb21faW5kaWNhdG9y",
+            "LnByb3RvIoEGChJSZXNlcnZhdGlvblN1bW1hcnkSRwoJZW50aXR5X2lkGAEg",
+            "ASgLMjQuaG9sbXMudHlwZXMuYm9va2luZy5pbmRpY2F0b3JzLlJlc2VydmF0",
+            "aW9uSW5kaWNhdG9yEhIKCmJvb2tpbmdfaWQYAiABKAkSQQoFc3RhdGUYAyAB",
+            "KA4yMi5ob2xtcy50eXBlcy5ib29raW5nLnJlc2VydmF0aW9ucy5SZXNlcnZh",
+            "dGlvblN0YXRlEiwKBWd1ZXN0GAQgASgLMh0uaG9sbXMudHlwZXMuY3JtLmd1",
+            "ZXN0cy5HdWVzdBJCCgpkYXRlX3JhbmdlGAUgASgLMi4uaG9sbXMudHlwZXMu",
+            "cHJpbWl0aXZlLlBiSW5jbHVzaXZlT3BzZGF0ZVJhbmdlEjoKCXJvb21fdHlw",
+            "ZRgGIAEoCzInLmhvbG1zLnR5cGVzLnN1cHBseS5yb29tX3R5cGVzLlJvb21U",
+            "eXBlElYKEGd1YXJhbnRlZV9zdGF0dXMYByABKA4yPC5ob2xtcy50eXBlcy5i",
+            "b29raW5nLnJlc2VydmF0aW9ucy5SZXNlcnZhdGlvbkd1YXJhbnRlZVN0YXR1",
+            "cxIyCgd0ZW5hbmN5GAggASgLMiEuaG9sbXMudHlwZXMuaWFtLlRlbmFuY3lJ",
+            "bmRpY2F0b3ISSgoIcHJvcGVydHkYCSABKAsyOC5ob2xtcy50eXBlcy50ZW5h",
+            "bmN5X2NvbmZpZy5pbmRpY2F0b3JzLlByb3BlcnR5SW5kaWNhdG9yEhgKEGdy",
+            "b3VwX2Jvb2tpbmdfaWQYCiABKAkSIQoZdmVoaWNsZV9wbGF0ZV9pbmZvcm1h",
+            "dGlvbhgLIAEoCRIwCihjdXJyZW50X29yX3Rlcm1pbmFsX29jY3VwaWVkX3Jv",
+            "b21fbnVtYmVyGAwgASgJElYKIWN1cnJlbnRfb3JfdGVybWluYWxfb2NjdXBp",
+            "ZWRfcm9vbRgNIAEoCzIrLmhvbG1zLnR5cGVzLm9wZXJhdGlvbnMucm9vbXMu",
+            "Um9vbUluZGljYXRvckI5WhRib29raW5nL3Jlc2VydmF0aW9uc6oCIEhPTE1T",
+            "LlR5cGVzLkJvb2tpbmcuUmVzZXJ2YXRpb25zYgZwcm90bzM="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
-          new pbr::FileDescriptor[] { global::HOLMS.Types.Booking.Reservations.ReservationGuaranteeStatusReflection.Descriptor, global::HOLMS.Types.Booking.Indicators.ReservationIndicatorReflection.Descriptor, global::HOLMS.Types.Booking.Reservations.ReservationStateReflection.Descriptor, global::HOLMS.Types.CRM.Guests.GuestReflection.Descriptor, global::HOLMS.Types.Primitive.PbInclusiveOpsdateRangeReflection.Descriptor, global::HOLMS.Types.Supply.RoomTypes.RoomTypeReflection.Descriptor, global::HOLMS.Types.IAM.TenancyIndicatorReflection.Descriptor, global::HOLMS.Types.TenancyConfig.Indicators.PropertyIndicatorReflection.Descriptor, },
+          new pbr::FileDescriptor[] { global::HOLMS.Types.Booking.Reservations.ReservationGuaranteeStatusReflection.Descriptor, global::HOLMS.Types.Booking.Indicators.ReservationIndicatorReflection.Descriptor, global::HOLMS.Types.Booking.Reservations.ReservationStateReflection.Descriptor, global::HOLMS.Types.CRM.Guests.GuestReflection.Descriptor, global::HOLMS.Types.Primitive.PbInclusiveOpsdateRangeReflection.Descriptor, global::HOLMS.Types.Supply.RoomTypes.RoomTypeReflection.Descriptor, global::HOLMS.Types.IAM.TenancyIndicatorReflection.Descriptor, global::HOLMS.Types.TenancyConfig.Indicators.PropertyIndicatorReflection.Descriptor, global::HOLMS.Types.Operations.Rooms.RoomIndicatorReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {
-            new pbr::GeneratedClrTypeInfo(typeof(global::HOLMS.Types.Booking.Reservations.ReservationSummary), global::HOLMS.Types.Booking.Reservations.ReservationSummary.Parser, new[]{ "EntityId", "BookingId", "State", "Guest", "DateRange", "RoomType", "GuaranteeStatus", "Tenancy", "Property", "GroupBookingId", "VehiclePlateInformation" }, null, null, null)
+            new pbr::GeneratedClrTypeInfo(typeof(global::HOLMS.Types.Booking.Reservations.ReservationSummary), global::HOLMS.Types.Booking.Reservations.ReservationSummary.Parser, new[]{ "EntityId", "BookingId", "State", "Guest", "DateRange", "RoomType", "GuaranteeStatus", "Tenancy", "Property", "GroupBookingId", "VehiclePlateInformation", "CurrentOrTerminalOccupiedRoomNumber", "CurrentOrTerminalOccupiedRoom" }, null, null, null)
           }));
     }
     #endregion
@@ -92,6 +96,8 @@ namespace HOLMS.Types.Booking.Reservations {
       Property = other.property_ != null ? other.Property.Clone() : null;
       groupBookingId_ = other.groupBookingId_;
       vehiclePlateInformation_ = other.vehiclePlateInformation_;
+      currentOrTerminalOccupiedRoomNumber_ = other.currentOrTerminalOccupiedRoomNumber_;
+      CurrentOrTerminalOccupiedRoom = other.currentOrTerminalOccupiedRoom_ != null ? other.CurrentOrTerminalOccupiedRoom.Clone() : null;
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -220,6 +226,28 @@ namespace HOLMS.Types.Booking.Reservations {
       }
     }
 
+    /// <summary>Field number for the "current_or_terminal_occupied_room_number" field.</summary>
+    public const int CurrentOrTerminalOccupiedRoomNumberFieldNumber = 12;
+    private string currentOrTerminalOccupiedRoomNumber_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public string CurrentOrTerminalOccupiedRoomNumber {
+      get { return currentOrTerminalOccupiedRoomNumber_; }
+      set {
+        currentOrTerminalOccupiedRoomNumber_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "current_or_terminal_occupied_room" field.</summary>
+    public const int CurrentOrTerminalOccupiedRoomFieldNumber = 13;
+    private global::HOLMS.Types.Operations.Rooms.RoomIndicator currentOrTerminalOccupiedRoom_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public global::HOLMS.Types.Operations.Rooms.RoomIndicator CurrentOrTerminalOccupiedRoom {
+      get { return currentOrTerminalOccupiedRoom_; }
+      set {
+        currentOrTerminalOccupiedRoom_ = value;
+      }
+    }
+
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as ReservationSummary);
@@ -244,6 +272,8 @@ namespace HOLMS.Types.Booking.Reservations {
       if (!object.Equals(Property, other.Property)) return false;
       if (GroupBookingId != other.GroupBookingId) return false;
       if (VehiclePlateInformation != other.VehiclePlateInformation) return false;
+      if (CurrentOrTerminalOccupiedRoomNumber != other.CurrentOrTerminalOccupiedRoomNumber) return false;
+      if (!object.Equals(CurrentOrTerminalOccupiedRoom, other.CurrentOrTerminalOccupiedRoom)) return false;
       return true;
     }
 
@@ -261,6 +291,8 @@ namespace HOLMS.Types.Booking.Reservations {
       if (property_ != null) hash ^= Property.GetHashCode();
       if (GroupBookingId.Length != 0) hash ^= GroupBookingId.GetHashCode();
       if (VehiclePlateInformation.Length != 0) hash ^= VehiclePlateInformation.GetHashCode();
+      if (CurrentOrTerminalOccupiedRoomNumber.Length != 0) hash ^= CurrentOrTerminalOccupiedRoomNumber.GetHashCode();
+      if (currentOrTerminalOccupiedRoom_ != null) hash ^= CurrentOrTerminalOccupiedRoom.GetHashCode();
       return hash;
     }
 
@@ -315,6 +347,14 @@ namespace HOLMS.Types.Booking.Reservations {
         output.WriteRawTag(90);
         output.WriteString(VehiclePlateInformation);
       }
+      if (CurrentOrTerminalOccupiedRoomNumber.Length != 0) {
+        output.WriteRawTag(98);
+        output.WriteString(CurrentOrTerminalOccupiedRoomNumber);
+      }
+      if (currentOrTerminalOccupiedRoom_ != null) {
+        output.WriteRawTag(106);
+        output.WriteMessage(CurrentOrTerminalOccupiedRoom);
+      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -352,6 +392,12 @@ namespace HOLMS.Types.Booking.Reservations {
       }
       if (VehiclePlateInformation.Length != 0) {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(VehiclePlateInformation);
+      }
+      if (CurrentOrTerminalOccupiedRoomNumber.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(CurrentOrTerminalOccupiedRoomNumber);
+      }
+      if (currentOrTerminalOccupiedRoom_ != null) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(CurrentOrTerminalOccupiedRoom);
       }
       return size;
     }
@@ -411,6 +457,15 @@ namespace HOLMS.Types.Booking.Reservations {
       }
       if (other.VehiclePlateInformation.Length != 0) {
         VehiclePlateInformation = other.VehiclePlateInformation;
+      }
+      if (other.CurrentOrTerminalOccupiedRoomNumber.Length != 0) {
+        CurrentOrTerminalOccupiedRoomNumber = other.CurrentOrTerminalOccupiedRoomNumber;
+      }
+      if (other.currentOrTerminalOccupiedRoom_ != null) {
+        if (currentOrTerminalOccupiedRoom_ == null) {
+          currentOrTerminalOccupiedRoom_ = new global::HOLMS.Types.Operations.Rooms.RoomIndicator();
+        }
+        CurrentOrTerminalOccupiedRoom.MergeFrom(other.CurrentOrTerminalOccupiedRoom);
       }
     }
 
@@ -482,6 +537,17 @@ namespace HOLMS.Types.Booking.Reservations {
           }
           case 90: {
             VehiclePlateInformation = input.ReadString();
+            break;
+          }
+          case 98: {
+            CurrentOrTerminalOccupiedRoomNumber = input.ReadString();
+            break;
+          }
+          case 106: {
+            if (currentOrTerminalOccupiedRoom_ == null) {
+              currentOrTerminalOccupiedRoom_ = new global::HOLMS.Types.Operations.Rooms.RoomIndicator();
+            }
+            input.ReadMessage(currentOrTerminalOccupiedRoom_);
             break;
           }
         }

--- a/proto/booking/reservations/complete_open_reservation.proto
+++ b/proto/booking/reservations/complete_open_reservation.proto
@@ -32,6 +32,8 @@ message CompleteOpenReservation {
 	holms.types.operations.housekeeping.HousekeepingTime hk_time_preference = 15;
 	string vehicle_plate_information = 16;
 
-	string current_or_terminal_occupied_room_number = 17;
-	holms.types.operations.rooms.RoomIndicator current_or_terminal_occupied_room = 18;
+	string current_occupied_room_number = 17;
+	holms.types.operations.rooms.RoomIndicator current_occupied_room = 18;
+	string terminal_occupied_room_number = 19;
+	holms.types.operations.rooms.RoomIndicator terminal_occupied_room = 20;
 }

--- a/proto/booking/reservations/complete_open_reservation.proto
+++ b/proto/booking/reservations/complete_open_reservation.proto
@@ -13,6 +13,7 @@ import "crm/guests/guest.proto";
 import "supply/room_types/room_type.proto";
 import "supply/qualification.proto";
 import "operations/housekeeping/housekeeping_time.proto";
+import "operations/rooms/room_indicator.proto";
 
 message CompleteOpenReservation {
 	holms.types.booking.indicators.ReservationIndicator entity_id = 1;
@@ -30,4 +31,7 @@ message CompleteOpenReservation {
 	holms.types.primitive.MonetaryAmount unpaid_guarantee_balance = 13;
 	holms.types.operations.housekeeping.HousekeepingTime hk_time_preference = 15;
 	string vehicle_plate_information = 16;
+
+	string current_or_terminal_occupied_room_number = 17;
+	holms.types.operations.rooms.RoomIndicator current_or_terminal_occupied_room = 18;
 }

--- a/proto/booking/reservations/reservation_summary.proto
+++ b/proto/booking/reservations/reservation_summary.proto
@@ -13,6 +13,8 @@ import "supply/room_types/room_type.proto";
 import "iam/tenancy_indicator.proto";
 import "tenancy_config/indicators/property_indicator.proto";
 
+import "operations/rooms/room_indicator.proto";
+
 message ReservationSummary {
 	holms.types.booking.indicators.ReservationIndicator entity_id = 1;
 	string booking_id = 2;
@@ -25,4 +27,7 @@ message ReservationSummary {
 	.holms.types.tenancy_config.indicators.PropertyIndicator property = 9;
 	string group_booking_id = 10;
 	string vehicle_plate_information = 11;
+
+	string current_or_terminal_occupied_room_number = 12;
+	holms.types.operations.rooms.RoomIndicator current_or_terminal_occupied_room = 13;
 }

--- a/proto/booking/reservations/reservation_summary.proto
+++ b/proto/booking/reservations/reservation_summary.proto
@@ -28,6 +28,8 @@ message ReservationSummary {
 	string group_booking_id = 10;
 	string vehicle_plate_information = 11;
 
-	string current_or_terminal_occupied_room_number = 12;
-	holms.types.operations.rooms.RoomIndicator current_or_terminal_occupied_room = 13;
+	string current_occupied_room_number = 12;
+	holms.types.operations.rooms.RoomIndicator current_occupied_room = 13;
+	string terminal_occupied_room_number = 14;
+	holms.types.operations.rooms.RoomIndicator terminal_occupied_room = 15;
 }


### PR DESCRIPTION
@eldavido PTAL

This adds information onto summary and complete reservation DTOs about the room occupancy status.

My plan is that the occupied room will be stored in materialized state as a room number string and an indicator (guid in the database) on the reservation model object. I'm calling this current-or-terminal occupancy because we have mutually-exclusive cases where we want to know the room occupancy of the reservation:

1) Upon observing a checked-in reservation, we wish to know the room it currently occupies
2) Upon observing a checked-out reservation, we wish to know the last room it occupied

These two cases occur in mutual exclusivity because occupancy is hard-released on checkout. Therefore, I decided to merge them into one field because,

1) It's simpler just to leave the field untouched when the reservation checks out
2) It's simpler for consumers, since they don't need to be concerned about multiple room occupancy fields based on the reservation state.