### PR TITLE
Adds vehicle plate and personal identification endpoints

### DIFF
--- a/csharp/HOLMS.Platform/HOLMS.Platform/Types/out/CheckInService.cs
+++ b/csharp/HOLMS.Platform/HOLMS.Platform/Types/out/CheckInService.cs
@@ -25,22 +25,41 @@ namespace HOLMS.Types.Booking.RPC {
             "CiJib29raW5nL3JwYy9jaGVja19pbl9zZXJ2aWNlLnByb3RvEhdob2xtcy50",
             "eXBlcy5ib29raW5nLnJwYxouYm9va2luZy9pbmRpY2F0b3JzL3Jlc2VydmF0",
             "aW9uX2luZGljYXRvci5wcm90bxouYm9va2luZy9jaGVja19pbi9jaGVja19p",
-            "bl9yZXF1ZXN0X3Jlc3VsdC5wcm90byKlAQoOQ2hlY2tJblJlcXVlc3QSSQoL",
-            "cmVzZXJ2YXRpb24YASABKAsyNC5ob2xtcy50eXBlcy5ib29raW5nLmluZGlj",
-            "YXRvcnMuUmVzZXJ2YXRpb25JbmRpY2F0b3ISFAoMcHJlc2VudGVkX2lkGAIg",
-            "ASgJEhIKCnZlaGljbGVfaWQYAyABKAkSHgoWcmVxdWVzdF9rZWVwX2d1YXJh",
-            "bnRlZRgEIAEoCCJjCh1DaGVja0luU2VydmljZVJlcXVlc3RSZXNwb25zZRJC",
-            "CgZyZXN1bHQYASABKA4yMi5ob2xtcy50eXBlcy5ib29raW5nLmNoZWNrX2lu",
-            "LkNoZWNrSW5SZXF1ZXN0UmVzdWx0Mn4KDkNoZWNrSW5TZXJ2aWNlEmwKCVN0",
-            "YXJ0U3RheRInLmhvbG1zLnR5cGVzLmJvb2tpbmcucnBjLkNoZWNrSW5SZXF1",
-            "ZXN0GjYuaG9sbXMudHlwZXMuYm9va2luZy5ycGMuQ2hlY2tJblNlcnZpY2VS",
-            "ZXF1ZXN0UmVzcG9uc2VCJ1oLYm9va2luZy9ycGOqAhdIT0xNUy5UeXBlcy5C",
-            "b29raW5nLlJQQ2IGcHJvdG8z"));
+            "bl9yZXF1ZXN0X3Jlc3VsdC5wcm90bxpJYm9va2luZy9yZXNlcnZhdGlvbnMv",
+            "cmVjb21tZW5kZWRfY2hlY2tpbl9jYXJkX2F1dGhvcml6YXRpb25fYW1vdW50",
+            "cy5wcm90bxobZ29vZ2xlL3Byb3RvYnVmL2VtcHR5LnByb3RvIqUBCg5DaGVj",
+            "a0luUmVxdWVzdBJJCgtyZXNlcnZhdGlvbhgBIAEoCzI0LmhvbG1zLnR5cGVz",
+            "LmJvb2tpbmcuaW5kaWNhdG9ycy5SZXNlcnZhdGlvbkluZGljYXRvchIUCgxw",
+            "cmVzZW50ZWRfaWQYAiABKAkSEgoKdmVoaWNsZV9pZBgDIAEoCRIeChZyZXF1",
+            "ZXN0X2tlZXBfZ3VhcmFudGVlGAQgASgIImMKHUNoZWNrSW5TZXJ2aWNlUmVx",
+            "dWVzdFJlc3BvbnNlEkIKBnJlc3VsdBgBIAEoDjIyLmhvbG1zLnR5cGVzLmJv",
+            "b2tpbmcuY2hlY2tfaW4uQ2hlY2tJblJlcXVlc3RSZXN1bHQijQIKGUdldFBy",
+            "ZUNoZWNraW5JbmZvUmVzcG9uc2USSQoLcmVzZXJ2YXRpb24YASABKAsyNC5o",
+            "b2xtcy50eXBlcy5ib29raW5nLmluZGljYXRvcnMuUmVzZXJ2YXRpb25JbmRp",
+            "Y2F0b3ISFgoOdmVoaWNsZV9wbGF0ZXMYAiABKAkSHwoXcGVyc29uYWxfaWRl",
+            "bnRpZmljYXRpb24YAyABKAkSbAoacmVjb21tZW5kZWRfYXV0aG9yaXphdGlv",
+            "bnMYBCABKAsySC5ob2xtcy50eXBlcy5ib29raW5nLnJlc2VydmF0aW9ucy5S",
+            "ZWNvbW1lbmRlZENoZWNraW5BdXRob3JpemF0aW9uQW1vdW50cyKeAQoYU2V0",
+            "UHJlQ2hlY2tpbkluZm9SZXF1ZXN0EkkKC3Jlc2VydmF0aW9uGAEgASgLMjQu",
+            "aG9sbXMudHlwZXMuYm9va2luZy5pbmRpY2F0b3JzLlJlc2VydmF0aW9uSW5k",
+            "aWNhdG9yEhYKDnZlaGljbGVfcGxhdGVzGAIgASgJEh8KF3BlcnNvbmFsX2lk",
+            "ZW50aWZpY2F0aW9uGAMgASgJMt0CCg5DaGVja0luU2VydmljZRJsCglTdGFy",
+            "dFN0YXkSJy5ob2xtcy50eXBlcy5ib29raW5nLnJwYy5DaGVja0luUmVxdWVz",
+            "dBo2LmhvbG1zLnR5cGVzLmJvb2tpbmcucnBjLkNoZWNrSW5TZXJ2aWNlUmVx",
+            "dWVzdFJlc3BvbnNlEn0KEUdldFByZUNoZWNraW5JbmZvEjQuaG9sbXMudHlw",
+            "ZXMuYm9va2luZy5pbmRpY2F0b3JzLlJlc2VydmF0aW9uSW5kaWNhdG9yGjIu",
+            "aG9sbXMudHlwZXMuYm9va2luZy5ycGMuR2V0UHJlQ2hlY2tpbkluZm9SZXNw",
+            "b25zZRJeChFTZXRQcmVDaGVja2luSW5mbxIxLmhvbG1zLnR5cGVzLmJvb2tp",
+            "bmcucnBjLlNldFByZUNoZWNraW5JbmZvUmVxdWVzdBoWLmdvb2dsZS5wcm90",
+            "b2J1Zi5FbXB0eUInWgtib29raW5nL3JwY6oCF0hPTE1TLlR5cGVzLkJvb2tp",
+            "bmcuUlBDYgZwcm90bzM="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
-          new pbr::FileDescriptor[] { global::HOLMS.Types.Booking.Indicators.ReservationIndicatorReflection.Descriptor, global::HOLMS.Types.Booking.CheckIn.CheckInRequestResultReflection.Descriptor, },
+          new pbr::FileDescriptor[] { global::HOLMS.Types.Booking.Indicators.ReservationIndicatorReflection.Descriptor, global::HOLMS.Types.Booking.CheckIn.CheckInRequestResultReflection.Descriptor, global::HOLMS.Types.Booking.Reservations.RecommendedCheckinCardAuthorizationAmountsReflection.Descriptor, global::Google.Protobuf.WellKnownTypes.EmptyReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {
             new pbr::GeneratedClrTypeInfo(typeof(global::HOLMS.Types.Booking.RPC.CheckInRequest), global::HOLMS.Types.Booking.RPC.CheckInRequest.Parser, new[]{ "Reservation", "PresentedId", "VehicleId", "RequestKeepGuarantee" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::HOLMS.Types.Booking.RPC.CheckInServiceRequestResponse), global::HOLMS.Types.Booking.RPC.CheckInServiceRequestResponse.Parser, new[]{ "Result" }, null, null, null)
+            new pbr::GeneratedClrTypeInfo(typeof(global::HOLMS.Types.Booking.RPC.CheckInServiceRequestResponse), global::HOLMS.Types.Booking.RPC.CheckInServiceRequestResponse.Parser, new[]{ "Result" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::HOLMS.Types.Booking.RPC.GetPreCheckinInfoResponse), global::HOLMS.Types.Booking.RPC.GetPreCheckinInfoResponse.Parser, new[]{ "Reservation", "VehiclePlates", "PersonalIdentification", "RecommendedAuthorizations" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::HOLMS.Types.Booking.RPC.SetPreCheckinInfoRequest), global::HOLMS.Types.Booking.RPC.SetPreCheckinInfoRequest.Parser, new[]{ "Reservation", "VehiclePlates", "PersonalIdentification" }, null, null, null)
           }));
     }
     #endregion
@@ -363,6 +382,398 @@ namespace HOLMS.Types.Booking.RPC {
             break;
           case 8: {
             result_ = (global::HOLMS.Types.Booking.CheckIn.CheckInRequestResult) input.ReadEnum();
+            break;
+          }
+        }
+      }
+    }
+
+  }
+
+  public sealed partial class GetPreCheckinInfoResponse : pb::IMessage<GetPreCheckinInfoResponse> {
+    private static readonly pb::MessageParser<GetPreCheckinInfoResponse> _parser = new pb::MessageParser<GetPreCheckinInfoResponse>(() => new GetPreCheckinInfoResponse());
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public static pb::MessageParser<GetPreCheckinInfoResponse> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::HOLMS.Types.Booking.RPC.CheckInServiceReflection.Descriptor.MessageTypes[2]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public GetPreCheckinInfoResponse() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public GetPreCheckinInfoResponse(GetPreCheckinInfoResponse other) : this() {
+      Reservation = other.reservation_ != null ? other.Reservation.Clone() : null;
+      vehiclePlates_ = other.vehiclePlates_;
+      personalIdentification_ = other.personalIdentification_;
+      RecommendedAuthorizations = other.recommendedAuthorizations_ != null ? other.RecommendedAuthorizations.Clone() : null;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public GetPreCheckinInfoResponse Clone() {
+      return new GetPreCheckinInfoResponse(this);
+    }
+
+    /// <summary>Field number for the "reservation" field.</summary>
+    public const int ReservationFieldNumber = 1;
+    private global::HOLMS.Types.Booking.Indicators.ReservationIndicator reservation_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public global::HOLMS.Types.Booking.Indicators.ReservationIndicator Reservation {
+      get { return reservation_; }
+      set {
+        reservation_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "vehicle_plates" field.</summary>
+    public const int VehiclePlatesFieldNumber = 2;
+    private string vehiclePlates_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public string VehiclePlates {
+      get { return vehiclePlates_; }
+      set {
+        vehiclePlates_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "personal_identification" field.</summary>
+    public const int PersonalIdentificationFieldNumber = 3;
+    private string personalIdentification_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public string PersonalIdentification {
+      get { return personalIdentification_; }
+      set {
+        personalIdentification_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "recommended_authorizations" field.</summary>
+    public const int RecommendedAuthorizationsFieldNumber = 4;
+    private global::HOLMS.Types.Booking.Reservations.RecommendedCheckinAuthorizationAmounts recommendedAuthorizations_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public global::HOLMS.Types.Booking.Reservations.RecommendedCheckinAuthorizationAmounts RecommendedAuthorizations {
+      get { return recommendedAuthorizations_; }
+      set {
+        recommendedAuthorizations_ = value;
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override bool Equals(object other) {
+      return Equals(other as GetPreCheckinInfoResponse);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public bool Equals(GetPreCheckinInfoResponse other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (!object.Equals(Reservation, other.Reservation)) return false;
+      if (VehiclePlates != other.VehiclePlates) return false;
+      if (PersonalIdentification != other.PersonalIdentification) return false;
+      if (!object.Equals(RecommendedAuthorizations, other.RecommendedAuthorizations)) return false;
+      return true;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (reservation_ != null) hash ^= Reservation.GetHashCode();
+      if (VehiclePlates.Length != 0) hash ^= VehiclePlates.GetHashCode();
+      if (PersonalIdentification.Length != 0) hash ^= PersonalIdentification.GetHashCode();
+      if (recommendedAuthorizations_ != null) hash ^= RecommendedAuthorizations.GetHashCode();
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void WriteTo(pb::CodedOutputStream output) {
+      if (reservation_ != null) {
+        output.WriteRawTag(10);
+        output.WriteMessage(Reservation);
+      }
+      if (VehiclePlates.Length != 0) {
+        output.WriteRawTag(18);
+        output.WriteString(VehiclePlates);
+      }
+      if (PersonalIdentification.Length != 0) {
+        output.WriteRawTag(26);
+        output.WriteString(PersonalIdentification);
+      }
+      if (recommendedAuthorizations_ != null) {
+        output.WriteRawTag(34);
+        output.WriteMessage(RecommendedAuthorizations);
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public int CalculateSize() {
+      int size = 0;
+      if (reservation_ != null) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(Reservation);
+      }
+      if (VehiclePlates.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(VehiclePlates);
+      }
+      if (PersonalIdentification.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(PersonalIdentification);
+      }
+      if (recommendedAuthorizations_ != null) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(RecommendedAuthorizations);
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void MergeFrom(GetPreCheckinInfoResponse other) {
+      if (other == null) {
+        return;
+      }
+      if (other.reservation_ != null) {
+        if (reservation_ == null) {
+          reservation_ = new global::HOLMS.Types.Booking.Indicators.ReservationIndicator();
+        }
+        Reservation.MergeFrom(other.Reservation);
+      }
+      if (other.VehiclePlates.Length != 0) {
+        VehiclePlates = other.VehiclePlates;
+      }
+      if (other.PersonalIdentification.Length != 0) {
+        PersonalIdentification = other.PersonalIdentification;
+      }
+      if (other.recommendedAuthorizations_ != null) {
+        if (recommendedAuthorizations_ == null) {
+          recommendedAuthorizations_ = new global::HOLMS.Types.Booking.Reservations.RecommendedCheckinAuthorizationAmounts();
+        }
+        RecommendedAuthorizations.MergeFrom(other.RecommendedAuthorizations);
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void MergeFrom(pb::CodedInputStream input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            input.SkipLastField();
+            break;
+          case 10: {
+            if (reservation_ == null) {
+              reservation_ = new global::HOLMS.Types.Booking.Indicators.ReservationIndicator();
+            }
+            input.ReadMessage(reservation_);
+            break;
+          }
+          case 18: {
+            VehiclePlates = input.ReadString();
+            break;
+          }
+          case 26: {
+            PersonalIdentification = input.ReadString();
+            break;
+          }
+          case 34: {
+            if (recommendedAuthorizations_ == null) {
+              recommendedAuthorizations_ = new global::HOLMS.Types.Booking.Reservations.RecommendedCheckinAuthorizationAmounts();
+            }
+            input.ReadMessage(recommendedAuthorizations_);
+            break;
+          }
+        }
+      }
+    }
+
+  }
+
+  public sealed partial class SetPreCheckinInfoRequest : pb::IMessage<SetPreCheckinInfoRequest> {
+    private static readonly pb::MessageParser<SetPreCheckinInfoRequest> _parser = new pb::MessageParser<SetPreCheckinInfoRequest>(() => new SetPreCheckinInfoRequest());
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public static pb::MessageParser<SetPreCheckinInfoRequest> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::HOLMS.Types.Booking.RPC.CheckInServiceReflection.Descriptor.MessageTypes[3]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public SetPreCheckinInfoRequest() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public SetPreCheckinInfoRequest(SetPreCheckinInfoRequest other) : this() {
+      Reservation = other.reservation_ != null ? other.Reservation.Clone() : null;
+      vehiclePlates_ = other.vehiclePlates_;
+      personalIdentification_ = other.personalIdentification_;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public SetPreCheckinInfoRequest Clone() {
+      return new SetPreCheckinInfoRequest(this);
+    }
+
+    /// <summary>Field number for the "reservation" field.</summary>
+    public const int ReservationFieldNumber = 1;
+    private global::HOLMS.Types.Booking.Indicators.ReservationIndicator reservation_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public global::HOLMS.Types.Booking.Indicators.ReservationIndicator Reservation {
+      get { return reservation_; }
+      set {
+        reservation_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "vehicle_plates" field.</summary>
+    public const int VehiclePlatesFieldNumber = 2;
+    private string vehiclePlates_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public string VehiclePlates {
+      get { return vehiclePlates_; }
+      set {
+        vehiclePlates_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "personal_identification" field.</summary>
+    public const int PersonalIdentificationFieldNumber = 3;
+    private string personalIdentification_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public string PersonalIdentification {
+      get { return personalIdentification_; }
+      set {
+        personalIdentification_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override bool Equals(object other) {
+      return Equals(other as SetPreCheckinInfoRequest);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public bool Equals(SetPreCheckinInfoRequest other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (!object.Equals(Reservation, other.Reservation)) return false;
+      if (VehiclePlates != other.VehiclePlates) return false;
+      if (PersonalIdentification != other.PersonalIdentification) return false;
+      return true;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (reservation_ != null) hash ^= Reservation.GetHashCode();
+      if (VehiclePlates.Length != 0) hash ^= VehiclePlates.GetHashCode();
+      if (PersonalIdentification.Length != 0) hash ^= PersonalIdentification.GetHashCode();
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void WriteTo(pb::CodedOutputStream output) {
+      if (reservation_ != null) {
+        output.WriteRawTag(10);
+        output.WriteMessage(Reservation);
+      }
+      if (VehiclePlates.Length != 0) {
+        output.WriteRawTag(18);
+        output.WriteString(VehiclePlates);
+      }
+      if (PersonalIdentification.Length != 0) {
+        output.WriteRawTag(26);
+        output.WriteString(PersonalIdentification);
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public int CalculateSize() {
+      int size = 0;
+      if (reservation_ != null) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(Reservation);
+      }
+      if (VehiclePlates.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(VehiclePlates);
+      }
+      if (PersonalIdentification.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(PersonalIdentification);
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void MergeFrom(SetPreCheckinInfoRequest other) {
+      if (other == null) {
+        return;
+      }
+      if (other.reservation_ != null) {
+        if (reservation_ == null) {
+          reservation_ = new global::HOLMS.Types.Booking.Indicators.ReservationIndicator();
+        }
+        Reservation.MergeFrom(other.Reservation);
+      }
+      if (other.VehiclePlates.Length != 0) {
+        VehiclePlates = other.VehiclePlates;
+      }
+      if (other.PersonalIdentification.Length != 0) {
+        PersonalIdentification = other.PersonalIdentification;
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void MergeFrom(pb::CodedInputStream input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            input.SkipLastField();
+            break;
+          case 10: {
+            if (reservation_ == null) {
+              reservation_ = new global::HOLMS.Types.Booking.Indicators.ReservationIndicator();
+            }
+            input.ReadMessage(reservation_);
+            break;
+          }
+          case 18: {
+            VehiclePlates = input.ReadString();
+            break;
+          }
+          case 26: {
+            PersonalIdentification = input.ReadString();
             break;
           }
         }

--- a/csharp/HOLMS.Platform/HOLMS.Platform/Types/out/CheckInServiceGrpc.cs
+++ b/csharp/HOLMS.Platform/HOLMS.Platform/Types/out/CheckInServiceGrpc.cs
@@ -14,6 +14,10 @@ namespace HOLMS.Types.Booking.RPC {
 
     static readonly Marshaller<global::HOLMS.Types.Booking.RPC.CheckInRequest> __Marshaller_CheckInRequest = Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::HOLMS.Types.Booking.RPC.CheckInRequest.Parser.ParseFrom);
     static readonly Marshaller<global::HOLMS.Types.Booking.RPC.CheckInServiceRequestResponse> __Marshaller_CheckInServiceRequestResponse = Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::HOLMS.Types.Booking.RPC.CheckInServiceRequestResponse.Parser.ParseFrom);
+    static readonly Marshaller<global::HOLMS.Types.Booking.Indicators.ReservationIndicator> __Marshaller_ReservationIndicator = Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::HOLMS.Types.Booking.Indicators.ReservationIndicator.Parser.ParseFrom);
+    static readonly Marshaller<global::HOLMS.Types.Booking.RPC.GetPreCheckinInfoResponse> __Marshaller_GetPreCheckinInfoResponse = Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::HOLMS.Types.Booking.RPC.GetPreCheckinInfoResponse.Parser.ParseFrom);
+    static readonly Marshaller<global::HOLMS.Types.Booking.RPC.SetPreCheckinInfoRequest> __Marshaller_SetPreCheckinInfoRequest = Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::HOLMS.Types.Booking.RPC.SetPreCheckinInfoRequest.Parser.ParseFrom);
+    static readonly Marshaller<global::Google.Protobuf.WellKnownTypes.Empty> __Marshaller_Empty = Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::Google.Protobuf.WellKnownTypes.Empty.Parser.ParseFrom);
 
     static readonly Method<global::HOLMS.Types.Booking.RPC.CheckInRequest, global::HOLMS.Types.Booking.RPC.CheckInServiceRequestResponse> __Method_StartStay = new Method<global::HOLMS.Types.Booking.RPC.CheckInRequest, global::HOLMS.Types.Booking.RPC.CheckInServiceRequestResponse>(
         MethodType.Unary,
@@ -21,6 +25,20 @@ namespace HOLMS.Types.Booking.RPC {
         "StartStay",
         __Marshaller_CheckInRequest,
         __Marshaller_CheckInServiceRequestResponse);
+
+    static readonly Method<global::HOLMS.Types.Booking.Indicators.ReservationIndicator, global::HOLMS.Types.Booking.RPC.GetPreCheckinInfoResponse> __Method_GetPreCheckinInfo = new Method<global::HOLMS.Types.Booking.Indicators.ReservationIndicator, global::HOLMS.Types.Booking.RPC.GetPreCheckinInfoResponse>(
+        MethodType.Unary,
+        __ServiceName,
+        "GetPreCheckinInfo",
+        __Marshaller_ReservationIndicator,
+        __Marshaller_GetPreCheckinInfoResponse);
+
+    static readonly Method<global::HOLMS.Types.Booking.RPC.SetPreCheckinInfoRequest, global::Google.Protobuf.WellKnownTypes.Empty> __Method_SetPreCheckinInfo = new Method<global::HOLMS.Types.Booking.RPC.SetPreCheckinInfoRequest, global::Google.Protobuf.WellKnownTypes.Empty>(
+        MethodType.Unary,
+        __ServiceName,
+        "SetPreCheckinInfo",
+        __Marshaller_SetPreCheckinInfoRequest,
+        __Marshaller_Empty);
 
     /// <summary>Service descriptor</summary>
     public static global::Google.Protobuf.Reflection.ServiceDescriptor Descriptor
@@ -32,6 +50,16 @@ namespace HOLMS.Types.Booking.RPC {
     public abstract class CheckInServiceBase
     {
       public virtual global::System.Threading.Tasks.Task<global::HOLMS.Types.Booking.RPC.CheckInServiceRequestResponse> StartStay(global::HOLMS.Types.Booking.RPC.CheckInRequest request, ServerCallContext context)
+      {
+        throw new RpcException(new Status(StatusCode.Unimplemented, ""));
+      }
+
+      public virtual global::System.Threading.Tasks.Task<global::HOLMS.Types.Booking.RPC.GetPreCheckinInfoResponse> GetPreCheckinInfo(global::HOLMS.Types.Booking.Indicators.ReservationIndicator request, ServerCallContext context)
+      {
+        throw new RpcException(new Status(StatusCode.Unimplemented, ""));
+      }
+
+      public virtual global::System.Threading.Tasks.Task<global::Google.Protobuf.WellKnownTypes.Empty> SetPreCheckinInfo(global::HOLMS.Types.Booking.RPC.SetPreCheckinInfoRequest request, ServerCallContext context)
       {
         throw new RpcException(new Status(StatusCode.Unimplemented, ""));
       }
@@ -77,6 +105,38 @@ namespace HOLMS.Types.Booking.RPC {
       {
         return CallInvoker.AsyncUnaryCall(__Method_StartStay, null, options, request);
       }
+      public virtual global::HOLMS.Types.Booking.RPC.GetPreCheckinInfoResponse GetPreCheckinInfo(global::HOLMS.Types.Booking.Indicators.ReservationIndicator request, Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken))
+      {
+        return GetPreCheckinInfo(request, new CallOptions(headers, deadline, cancellationToken));
+      }
+      public virtual global::HOLMS.Types.Booking.RPC.GetPreCheckinInfoResponse GetPreCheckinInfo(global::HOLMS.Types.Booking.Indicators.ReservationIndicator request, CallOptions options)
+      {
+        return CallInvoker.BlockingUnaryCall(__Method_GetPreCheckinInfo, null, options, request);
+      }
+      public virtual AsyncUnaryCall<global::HOLMS.Types.Booking.RPC.GetPreCheckinInfoResponse> GetPreCheckinInfoAsync(global::HOLMS.Types.Booking.Indicators.ReservationIndicator request, Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken))
+      {
+        return GetPreCheckinInfoAsync(request, new CallOptions(headers, deadline, cancellationToken));
+      }
+      public virtual AsyncUnaryCall<global::HOLMS.Types.Booking.RPC.GetPreCheckinInfoResponse> GetPreCheckinInfoAsync(global::HOLMS.Types.Booking.Indicators.ReservationIndicator request, CallOptions options)
+      {
+        return CallInvoker.AsyncUnaryCall(__Method_GetPreCheckinInfo, null, options, request);
+      }
+      public virtual global::Google.Protobuf.WellKnownTypes.Empty SetPreCheckinInfo(global::HOLMS.Types.Booking.RPC.SetPreCheckinInfoRequest request, Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken))
+      {
+        return SetPreCheckinInfo(request, new CallOptions(headers, deadline, cancellationToken));
+      }
+      public virtual global::Google.Protobuf.WellKnownTypes.Empty SetPreCheckinInfo(global::HOLMS.Types.Booking.RPC.SetPreCheckinInfoRequest request, CallOptions options)
+      {
+        return CallInvoker.BlockingUnaryCall(__Method_SetPreCheckinInfo, null, options, request);
+      }
+      public virtual AsyncUnaryCall<global::Google.Protobuf.WellKnownTypes.Empty> SetPreCheckinInfoAsync(global::HOLMS.Types.Booking.RPC.SetPreCheckinInfoRequest request, Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken))
+      {
+        return SetPreCheckinInfoAsync(request, new CallOptions(headers, deadline, cancellationToken));
+      }
+      public virtual AsyncUnaryCall<global::Google.Protobuf.WellKnownTypes.Empty> SetPreCheckinInfoAsync(global::HOLMS.Types.Booking.RPC.SetPreCheckinInfoRequest request, CallOptions options)
+      {
+        return CallInvoker.AsyncUnaryCall(__Method_SetPreCheckinInfo, null, options, request);
+      }
       protected override CheckInServiceClient NewInstance(ClientBaseConfiguration configuration)
       {
         return new CheckInServiceClient(configuration);
@@ -87,7 +147,9 @@ namespace HOLMS.Types.Booking.RPC {
     public static ServerServiceDefinition BindService(CheckInServiceBase serviceImpl)
     {
       return ServerServiceDefinition.CreateBuilder()
-          .AddMethod(__Method_StartStay, serviceImpl.StartStay).Build();
+          .AddMethod(__Method_StartStay, serviceImpl.StartStay)
+          .AddMethod(__Method_GetPreCheckinInfo, serviceImpl.GetPreCheckinInfo)
+          .AddMethod(__Method_SetPreCheckinInfo, serviceImpl.SetPreCheckinInfo).Build();
     }
 
   }

--- a/csharp/HOLMS.Platform/HOLMS.Platform/Types/out/OpenLodgingReservationSvcGrpc.cs
+++ b/csharp/HOLMS.Platform/HOLMS.Platform/Types/out/OpenLodgingReservationSvcGrpc.cs
@@ -156,6 +156,9 @@ namespace HOLMS.Types.Booking.RPC {
         throw new RpcException(new Status(StatusCode.Unimplemented, ""));
       }
 
+      /// <summary>
+      ///  Obsolete, use endpoint on check-in service instead
+      /// </summary>
       public virtual global::System.Threading.Tasks.Task<global::HOLMS.Types.Booking.Reservations.RecommendedCheckinAuthorizationAmounts> GetRecommendedCheckinAuthorizationAmounts(global::HOLMS.Types.Booking.Indicators.ReservationIndicator request, ServerCallContext context)
       {
         throw new RpcException(new Status(StatusCode.Unimplemented, ""));
@@ -318,18 +321,30 @@ namespace HOLMS.Types.Booking.RPC {
       {
         return CallInvoker.AsyncUnaryCall(__Method_SetHousekeepingTimePreference, null, options, request);
       }
+      /// <summary>
+      ///  Obsolete, use endpoint on check-in service instead
+      /// </summary>
       public virtual global::HOLMS.Types.Booking.Reservations.RecommendedCheckinAuthorizationAmounts GetRecommendedCheckinAuthorizationAmounts(global::HOLMS.Types.Booking.Indicators.ReservationIndicator request, Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken))
       {
         return GetRecommendedCheckinAuthorizationAmounts(request, new CallOptions(headers, deadline, cancellationToken));
       }
+      /// <summary>
+      ///  Obsolete, use endpoint on check-in service instead
+      /// </summary>
       public virtual global::HOLMS.Types.Booking.Reservations.RecommendedCheckinAuthorizationAmounts GetRecommendedCheckinAuthorizationAmounts(global::HOLMS.Types.Booking.Indicators.ReservationIndicator request, CallOptions options)
       {
         return CallInvoker.BlockingUnaryCall(__Method_GetRecommendedCheckinAuthorizationAmounts, null, options, request);
       }
+      /// <summary>
+      ///  Obsolete, use endpoint on check-in service instead
+      /// </summary>
       public virtual AsyncUnaryCall<global::HOLMS.Types.Booking.Reservations.RecommendedCheckinAuthorizationAmounts> GetRecommendedCheckinAuthorizationAmountsAsync(global::HOLMS.Types.Booking.Indicators.ReservationIndicator request, Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken))
       {
         return GetRecommendedCheckinAuthorizationAmountsAsync(request, new CallOptions(headers, deadline, cancellationToken));
       }
+      /// <summary>
+      ///  Obsolete, use endpoint on check-in service instead
+      /// </summary>
       public virtual AsyncUnaryCall<global::HOLMS.Types.Booking.Reservations.RecommendedCheckinAuthorizationAmounts> GetRecommendedCheckinAuthorizationAmountsAsync(global::HOLMS.Types.Booking.Indicators.ReservationIndicator request, CallOptions options)
       {
         return CallInvoker.AsyncUnaryCall(__Method_GetRecommendedCheckinAuthorizationAmounts, null, options, request);

--- a/proto/booking/rpc/check_in_service.proto
+++ b/proto/booking/rpc/check_in_service.proto
@@ -20,14 +20,14 @@ message CheckInServiceRequestResponse {
 	.holms.types.booking.check_in.CheckInRequestResult result = 1;
 }
 
-message GetPreCheckinInfoResponse {
+message CheckInSvcGetPreCheckinInfoResponse {
 	holms.types.booking.indicators.ReservationIndicator reservation = 1;
 	string vehicle_plates = 2;
 	string personal_identification = 3;
 	holms.types.booking.reservations.RecommendedCheckinAuthorizationAmounts recommended_authorizations = 4;
 }
 
-message SetPreCheckinInfoRequest {
+message CheckInSvcSetPreCheckinInfoRequest {
 	holms.types.booking.indicators.ReservationIndicator reservation = 1;
 	string vehicle_plates = 2;
 	string personal_identification = 3;
@@ -38,8 +38,8 @@ service CheckInService {
 		returns (CheckInServiceRequestResponse);
 
 	rpc GetPreCheckinInfo (holms.types.booking.indicators.ReservationIndicator)
-		returns (GetPreCheckinInfoResponse);
+		returns (CheckInSvcGetPreCheckinInfoResponse);
 
-	rpc SetPreCheckinInfo (SetPreCheckinInfoRequest)
+	rpc SetPreCheckinInfo (CheckInSvcSetPreCheckinInfoRequest)
 		returns (google.protobuf.Empty);
 }

--- a/proto/booking/rpc/check_in_service.proto
+++ b/proto/booking/rpc/check_in_service.proto
@@ -6,6 +6,8 @@ option go_package = "booking/rpc";
 
 import "booking/indicators/reservation_indicator.proto";
 import "booking/check_in/check_in_request_result.proto";
+import "booking/reservations/recommended_checkin_card_authorization_amounts.proto";
+import "google/protobuf/empty.proto";
 
 message CheckInRequest {
 	holms.types.booking.indicators.ReservationIndicator reservation = 1;
@@ -18,7 +20,26 @@ message CheckInServiceRequestResponse {
 	.holms.types.booking.check_in.CheckInRequestResult result = 1;
 }
 
+message GetPreCheckinInfoResponse {
+	holms.types.booking.indicators.ReservationIndicator reservation = 1;
+	string vehicle_plates = 2;
+	string personal_identification = 3;
+	holms.types.booking.reservations.RecommendedCheckinAuthorizationAmounts recommended_authorizations = 4;
+}
+
+message SetPreCheckinInfoRequest {
+	holms.types.booking.indicators.ReservationIndicator reservation = 1;
+	string vehicle_plates = 2;
+	string personal_identification = 3;
+}
+
 service CheckInService {
 	rpc StartStay (CheckInRequest)
 		returns (CheckInServiceRequestResponse);
+
+	rpc GetPreCheckinInfo (holms.types.booking.indicators.ReservationIndicator)
+		returns (GetPreCheckinInfoResponse);
+
+	rpc SetPreCheckinInfo (SetPreCheckinInfoRequest)
+		returns (google.protobuf.Empty);
 }

--- a/proto/booking/rpc/open_lodging_reservation_svc.proto
+++ b/proto/booking/rpc/open_lodging_reservation_svc.proto
@@ -78,6 +78,7 @@ service OpenLodgingReservationSvc {
 	rpc SetHousekeepingTimePreference(HousekeepingTimePreferenceRequest)
 		returns (google.protobuf.Empty);
 
+// Obsolete, use endpoint on check-in service instead
 	rpc GetRecommendedCheckinAuthorizationAmounts(holms.types.booking.indicators.ReservationIndicator)
 		returns (holms.types.booking.reservations.RecommendedCheckinAuthorizationAmounts);
 


### PR DESCRIPTION
@eldavido PTAL

Get/Set endpoints for pre-checkin information.

Pre-checkin info lumped together with recommended authorization amounts. I moved the endpoint to the check-in service and marked the old recommended authorization amounts obsolete. We can delete it once everything is moved to the new endpoint so we don't sit on any breaking changes in platform.