### PR TITLE
[#133867523] Adds opsdate conversions to support

### DIFF
--- a/csharp/HOLMS.Platform/HOLMS.Platform/HOLMS.Platform.csproj
+++ b/csharp/HOLMS.Platform/HOLMS.Platform/HOLMS.Platform.csproj
@@ -83,6 +83,7 @@
     <Compile Include="Support\DTOExtensions\Money\NonAuthoritativeTaxFeeCalculator.cs" />
     <Compile Include="Support\DTOExtensions\Primitive\ContactInfoExtensions.cs" />
     <Compile Include="Support\DTOExtensions\Supply\Packages\LodgingPackageExtensions.cs" />
+    <Compile Include="Support\DTOExtensions\TenancyConfig\PropertyExtensions.cs" />
     <Compile Include="Support\DTOExtensions\TransactionLineExtensions.cs" />
     <Compile Include="Support\IIFExportFrequency.cs" />
     <Compile Include="Support\PingTracker.cs" />
@@ -589,7 +590,6 @@
     <Compile Include="Types\Topics\PBXConnectorTopics.cs" />
     <Compile Include="Types\Topics\SupplyContextTopics.cs" />
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/csharp/HOLMS.Platform/HOLMS.Platform/HOLMS.Platform.nuget.targets
+++ b/csharp/HOLMS.Platform/HOLMS.Platform/HOLMS.Platform.nuget.targets
@@ -4,6 +4,6 @@
     <NuGetPackageRoot>$(UserProfile)\.nuget\packages\</NuGetPackageRoot>
   </PropertyGroup>
   <ImportGroup>
-    <Import Project="$(NuGetPackageRoot)\NodaTime\2.0.0-alpha20160729\build\NodaTime.targets" Condition="Exists('$(NuGetPackageRoot)\NodaTime\2.0.0-alpha20160729\build\NodaTime.targets')" />
+    <Import Project="$(NuGetPackageRoot)nodatime\2.0.0-alpha20160729\build\NodaTime.targets" Condition="Exists('$(NuGetPackageRoot)nodatime\2.0.0-alpha20160729\build\NodaTime.targets')" />
   </ImportGroup>
 </Project>

--- a/csharp/HOLMS.Platform/HOLMS.Platform/Support/DTOExtensions/TenancyConfig/PropertyExtensions.cs
+++ b/csharp/HOLMS.Platform/HOLMS.Platform/Support/DTOExtensions/TenancyConfig/PropertyExtensions.cs
@@ -1,0 +1,23 @@
+﻿using HOLMS.Types.TenancyConfig;
+using NodaTime;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using HOLMS.Support.Time;
+
+namespace HOLMS.Platform.Support.DTOExtensions.TenancyConfig {
+    public static class PropertyExtensions {
+        public static LocalDate GetOpsdateForDateTime(this Property p, DateTime currentLocalTime) {
+            var offset = p.CheckinTimeOfDay.ToTimeSpan();
+            var opsDateTime = currentLocalTime - offset;
+            return opsDateTime.Date.ConvertDateTimeLocalDate();
+        }
+
+        public static bool IsAllowedCheckinTime(this Property p, DateTime currentLocalTime, LocalDate arrivalOpsdate) {
+            var offset = p.CheckinTimeOfDay.ToTimeSpan().Subtract(new TimeSpan(Convert.ToInt32(p.AllowedEarlyCheckinHours), 0, 0));
+            return (currentLocalTime - offset).ConvertDateTimeLocalDate() >= arrivalOpsdate; 
+        }
+    }
+}


### PR DESCRIPTION
@eldavido PTAL

This is in service of: https://www.pivotaltracker.com/story/show/133867523

This logic was originally on the Property model object. The problem is that we often don't have access to the property object and I'd rather not have to round trip to the application service to figure out opsdate conversions. I consider opsdates as a more fundamental concept than our model.