### PR TITLE
Removes requirement for non-null sender in mailboxentry builder.

### DIFF
--- a/csharp/HOLMS.Platform/HOLMS.Platform/Support/DTOBuilders/Operations/MailboxEntryBuilder.cs
+++ b/csharp/HOLMS.Platform/HOLMS.Platform/Support/DTOBuilders/Operations/MailboxEntryBuilder.cs
@@ -27,20 +27,19 @@ namespace HOLMS.Support.DTOBuilders.Operations {
         }
 
         public MailboxEntry Build() {
-            if (_sender == null) {
-                throw new ArgumentNullException("Sender cannot be null");
-            }
-
             var mbe = new MailboxEntry {
                 EntityId = _ind,
                 Body = _body ?? string.Empty,
                 CreatedAt = _createdAt.ToTS(),
-                Sender = _sender,
                 Subject = _subject ?? string.Empty,
             };
 
             if (_viewedAt.HasValue) {
                 mbe.ViewedAt = _viewedAt.Value.ToTS();
+            }
+
+            if (_sender != null) {
+                mbe.Sender = _sender;
             }
 
             if (_recipients != null) {


### PR DESCRIPTION
[#136141653]

https://www.pivotaltracker.com/story/show/136141653

Somewhere along the way, someone encountered an issue with a null in proto and decided the solution was to prevent nulls. There are currently 2 use cases for the mailbox entry builder: 

1. StaffMsgSvc - The StaffMsgSvc grabs the mailbox entries for the current users and uses the mailbox entry builder to create them. In this case the sender is populated.
2. LodgeIC - New Message (brand new or reply / forward). LodgeIC just hits the server endpoint when actually sending the message, and the server assigns the sender based on the current user. It ignores the sender field.

Neither of these cases require that the sender be not null. This might fix the entire bug, but once this is approved, I'll get it into application / lodgeic and see what happens and go from there.