### PR TITLE
Add tag for migrated reservations

### DIFF
--- a/csharp/HOLMS.Platform/HOLMS.Platform/HOLMS.Platform.csproj
+++ b/csharp/HOLMS.Platform/HOLMS.Platform/HOLMS.Platform.csproj
@@ -87,6 +87,7 @@
     <Compile Include="Support\RecurrenceDescriptorParts.cs" />
     <Compile Include="Support\ReservationTags\CompStayTag.cs" />
     <Compile Include="Support\ReservationTags\GroupBookingTag.cs" />
+    <Compile Include="Support\ReservationTags\MigratedReservationTag.cs" />
     <Compile Include="Support\ReservationTags\OTABookingTag.cs" />
     <Compile Include="Support\ReservationTags\ReservationTagBase.cs" />
     <Compile Include="Support\ReservationTags\ReservationTagBaseTests.cs" />

--- a/csharp/HOLMS.Platform/HOLMS.Platform/Support/ReservationTags/CompStayTag.cs
+++ b/csharp/HOLMS.Platform/HOLMS.Platform/Support/ReservationTags/CompStayTag.cs
@@ -2,19 +2,9 @@
 
 namespace HOLMS.Platform.Support.ReservationTags {
     public class CompStayTag : ReservationTagBase {
-        public CompStayTag() { }
+        public override bool IsPermanent => false;
 
-        public CompStayTag(string[] tokens) { }
-
-        public override bool IsPermanent {
-            get {
-                return false;
-            }
-        }
-
-        protected override string GetCategoryDescriptor() {
-            return CompStayCategory;
-        }
+        protected override string GetCategoryDescriptor() => CompStayCategory;
 
         protected override string[] GetDescriptorPartsAfterCategory() {
             return new string[] { };

--- a/csharp/HOLMS.Platform/HOLMS.Platform/Support/ReservationTags/MigratedReservationTag.cs
+++ b/csharp/HOLMS.Platform/HOLMS.Platform/Support/ReservationTags/MigratedReservationTag.cs
@@ -1,0 +1,10 @@
+﻿namespace HOLMS.Platform.Support.ReservationTags {
+    class MigratedReservationTag : ReservationTagBase {
+        protected override string[] GetDescriptorPartsAfterCategory() =>
+            new string[] { };
+
+        protected override string GetCategoryDescriptor() => MigratedBookingCategory;
+
+        public override bool IsPermanent => true;
+    }
+}

--- a/csharp/HOLMS.Platform/HOLMS.Platform/Support/ReservationTags/ReservationTagBase.cs
+++ b/csharp/HOLMS.Platform/HOLMS.Platform/Support/ReservationTags/ReservationTagBase.cs
@@ -9,6 +9,7 @@ namespace HOLMS.Platform.Support.ReservationTags {
         // string<->type mapping.
         protected const string CompStayCategory = "comp";
         protected const string GroupBookingCategory = "gb";
+        protected const string MigratedBookingCategory = "migrated";
         protected const string OTABookingCategory = "ob";
 
         protected abstract string[] GetDescriptorPartsAfterCategory();
@@ -35,9 +36,11 @@ namespace HOLMS.Platform.Support.ReservationTags {
 
             switch (descriptorTokens.First()) {
                 case CompStayCategory:
-                    return new CompStayTag(descriptorTokens);
+                    return new CompStayTag();
                 case GroupBookingCategory:
                     return new GroupBookingTag(descriptorTokens);
+                case MigratedBookingCategory:
+                    return new MigratedReservationTag();
                 case OTABookingCategory:
                     return new OTABookingTag(descriptorTokens);
                 default:


### PR DESCRIPTION
@laxderek - adding this to allow reservations to be marked as part of the migration.

If a reservation is part of the migration, and it was created earlier than a certain date, we treat it as guaranteed, so that we don't have a whole stack of unguaranteed reservations going back ages.

I want to get to the point where a reservation's guarantee state conveys useful information about the state of the property, and is something a GSA can proactively try to fix, rather than having hundreds of them floating around all the time.