### PR TITLE
[#141436737] Adds void reservation state

### DIFF
--- a/csharp/HOLMS.Platform/HOLMS.Platform/Types/out/ReservationState.cs
+++ b/csharp/HOLMS.Platform/HOLMS.Platform/Types/out/ReservationState.cs
@@ -23,10 +23,11 @@ namespace HOLMS.Types.Booking.Reservations {
       byte[] descriptorData = global::System.Convert.FromBase64String(
           string.Concat(
             "Cixib29raW5nL3Jlc2VydmF0aW9ucy9yZXNlcnZhdGlvbl9zdGF0ZS5wcm90",
-            "bxIgaG9sbXMudHlwZXMuYm9va2luZy5yZXNlcnZhdGlvbnMqSgoQUmVzZXJ2",
+            "bxIgaG9sbXMudHlwZXMuYm9va2luZy5yZXNlcnZhdGlvbnMqVAoQUmVzZXJ2",
             "YXRpb25TdGF0ZRIICgRPcGVuEAASDQoJQ2FuY2VsbGVkEAESDQoJQ2hlY2tl",
-            "ZEluEAISDgoKQ2hlY2tlZE91dBADQjlaFGJvb2tpbmcvcmVzZXJ2YXRpb25z",
-            "qgIgSE9MTVMuVHlwZXMuQm9va2luZy5SZXNlcnZhdGlvbnNiBnByb3RvMw=="));
+            "ZEluEAISDgoKQ2hlY2tlZE91dBADEggKBFZvaWQQBEI5WhRib29raW5nL3Jl",
+            "c2VydmF0aW9uc6oCIEhPTE1TLlR5cGVzLkJvb2tpbmcuUmVzZXJ2YXRpb25z",
+            "YgZwcm90bzM="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { },
           new pbr::GeneratedClrTypeInfo(new[] {typeof(global::HOLMS.Types.Booking.Reservations.ReservationState), }, null));
@@ -40,6 +41,7 @@ namespace HOLMS.Types.Booking.Reservations {
     [pbr::OriginalName("Cancelled")] Cancelled = 1,
     [pbr::OriginalName("CheckedIn")] CheckedIn = 2,
     [pbr::OriginalName("CheckedOut")] CheckedOut = 3,
+    [pbr::OriginalName("Void")] Void = 4,
   }
 
   #endregion

--- a/proto/booking/reservations/reservation_state.proto
+++ b/proto/booking/reservations/reservation_state.proto
@@ -9,4 +9,5 @@ enum ReservationState {
         Cancelled = 1;
         CheckedIn = 2;
         CheckedOut = 3;
+		Void = 4;
 }


### PR DESCRIPTION
This is a tiny, but impactful proposed change.

Void state is similar to canceled. A void reservation cannot be checked
in/checked out, or cancelled. It does not contribute to supply claims, or
display on reports. It is a "This formerly-open reservation does not
exist." Void reservations are hidden from all but GetByID queries.

The purpose of this is that in the case of an OpTA booking with multiple
room stays, one room stay may commit, but another will fail. In this case
we cannot confirm to the channel manager the successful booking of the
reservation, so we remove any reservations that were created. Void is
distinct from cancelled because cancellations follow certain business
processes, and continue to impact the system. The rollback is done because
it is highly likely than a user-implemented resolution to the failed
booking would create a duplicate reservation.