### PR TITLE
Allow passing a null IEnumerable<ReservationTagBase>

### DIFF
--- a/csharp/HOLMS.Platform/HOLMS.Platform/HOLMS.Platform.nuget.targets
+++ b/csharp/HOLMS.Platform/HOLMS.Platform/HOLMS.Platform.nuget.targets
@@ -1,9 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup Condition="'$(NuGetPackageRoot)' == ''">
-    <NuGetPackageRoot>$(UserProfile)\.nuget\packages\</NuGetPackageRoot>
+  <PropertyGroup Condition=" '$(ExcludeRestorePackageImports)' != 'true' ">
+    <RestoreSuccess Condition=" '$(RestoreSuccess)' == '' ">True</RestoreSuccess>
+    <RestoreTool Condition=" '$(RestoreTool)' == '' ">NuGet</RestoreTool>
+    <ProjectAssetsFile Condition=" '$(ProjectAssetsFile)' == '' ">D:\code\holms.platform\csharp\HOLMS.Platform\HOLMS.Platform\project.lock.json</ProjectAssetsFile>
+    <NuGetPackageRoot Condition=" '$(NuGetPackageRoot)' == '' ">$(UserProfile)\.nuget\packages\</NuGetPackageRoot>
+    <NuGetPackageFolders Condition=" '$(NuGetPackageFolders)' == '' ">C:\Users\albre\.nuget\packages\</NuGetPackageFolders>
+    <NuGetProjectStyle Condition=" '$(NuGetProjectStyle)' == '' ">ProjectJson</NuGetProjectStyle>
+    <NuGetToolVersion Condition=" '$(NuGetToolVersion)' == '' ">4.0.0</NuGetToolVersion>
   </PropertyGroup>
-  <ImportGroup>
-    <Import Project="$(NuGetPackageRoot)\NodaTime\2.0.0-alpha20160729\build\NodaTime.targets" Condition="Exists('$(NuGetPackageRoot)\NodaTime\2.0.0-alpha20160729\build\NodaTime.targets')" />
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
+  <ImportGroup Condition=" '$(ExcludeRestorePackageImports)' != 'true' ">
+    <Import Project="$(NuGetPackageRoot)nodatime\2.0.0-alpha20160729\build\NodaTime.targets" Condition="Exists('$(NuGetPackageRoot)nodatime\2.0.0-alpha20160729\build\NodaTime.targets')" />
   </ImportGroup>
 </Project>

--- a/csharp/HOLMS.Platform/HOLMS.Platform/Support/ReservationTags/ImmutableTagSet.cs
+++ b/csharp/HOLMS.Platform/HOLMS.Platform/Support/ReservationTags/ImmutableTagSet.cs
@@ -27,6 +27,10 @@ namespace HOLMS.Platform.Support.ReservationTags {
         }
 
         public ImmutableTagSet(IEnumerable<ReservationTagBase> tags) : this() {
+            if (tags == null) {
+                return;
+            }
+
             foreach (var tag in tags) {
                 _tags.Add(tag);
             }


### PR DESCRIPTION
This makes initializing a ReservationTagBase more convenient, as sometimes
the incoming list is empty.