### PR TITLE
Consolodates IIF export into single endpoint

### DIFF
--- a/csharp/HOLMS.Platform/HOLMS.Platform/Types/out/AccountingTxnSvc.cs
+++ b/csharp/HOLMS.Platform/HOLMS.Platform/Types/out/AccountingTxnSvc.cs
@@ -23,46 +23,37 @@ namespace HOLMS.Types.Money.RPC {
       byte[] descriptorData = global::System.Convert.FromBase64String(
           string.Concat(
             "CiJtb25leS9ycGMvYWNjb3VudGluZ190eG5fc3ZjLnByb3RvEhVob2xtcy50",
-            "eXBlcy5tb25leS5ycGMaG2dvb2dsZS9wcm90b2J1Zi9lbXB0eS5wcm90bxof",
-            "Z29vZ2xlL3Byb3RvYnVmL3RpbWVzdGFtcC5wcm90bxowcHJpbWl0aXZlL3Bi",
-            "X2luY2x1c2l2ZV9jYWxlbmRhcl9kYXRlX3JhbmdlLnByb3RvGiBjcm0vZ3Vl",
-            "c3RzL2d1ZXN0X2luZGljYXRvci5wcm90bxo7bW9uZXkvYWNjb3VudGluZy9h",
-            "Y2NvdW50aW5nX3RyYW5zYWN0aW9uX2V4cG9ydF9mb3JtYXQucHJvdG8aM21v",
-            "bmV5L2FjY291bnRpbmcvYWNjb3VudGluZ190eG5fZXhwb3J0X3N0YXR1cy5w",
-            "cm90bxo4bW9uZXkvYWNjb3VudGluZy9hY2NvdW50aW5nX3RyYW5zYWN0aW9u",
-            "X3dpdGhfZ3Vlc3QucHJvdG8aMnRlbmFuY3lfY29uZmlnL2luZGljYXRvcnMv",
-            "cHJvcGVydHlfaW5kaWNhdG9yLnByb3RvIroBChhBc3NpZ25HdWVzdE93bmVy",
-            "VG9UeG5SZXESZwohYWNjb3VudGluZ190cmFuc2FjdGlvbl93aXRoX2d1ZXN0",
-            "GAEgASgLMjwuaG9sbXMudHlwZXMubW9uZXkuYWNjb3VudGluZy5BY2NvdW50",
-            "aW5nVHJhbnNhY3Rpb25XaXRoR3Vlc3QSNQoFZ3Vlc3QYAiABKAsyJi5ob2xt",
-            "cy50eXBlcy5jcm0uZ3Vlc3RzLkd1ZXN0SW5kaWNhdG9yIqECCjlBY2NvdW50",
-            "VHhuRXhwb3J0U3ZjR2V0UHJvcGVydHlUcmFuc2FjdGlvbnNJbkZvcm1hdFJl",
-            "cXVlc3QSTwoGZm9ybWF0GAEgASgOMj8uaG9sbXMudHlwZXMubW9uZXkuYWNj",
-            "b3VudGluZy5BY2NvdW50aW5nVHJhbnNhY3Rpb25FeHBvcnRGb3JtYXQSSgoI",
-            "cHJvcGVydHkYAiABKAsyOC5ob2xtcy50eXBlcy50ZW5hbmN5X2NvbmZpZy5p",
-            "bmRpY2F0b3JzLlByb3BlcnR5SW5kaWNhdG9yEkcKCmRhdGVfcmFuZ2UYAyAB",
-            "KAsyMy5ob2xtcy50eXBlcy5wcmltaXRpdmUuUGJJbmNsdXNpdmVDYWxlbmRh",
-            "ckRhdGVSYW5nZSJbCjpBY2NvdW50VHhuRXhwb3J0U3ZjR2V0UHJvcGVydHlU",
-            "cmFuc2FjdGlvbnNJbkZvcm1hdFJlc3BvbnNlEh0KFWV4cG9ydGVkX3RyYW5z",
-            "YWN0aW9ucxgBIAEoDDL7AwoQQWNjb3VudGluZ1R4blN2YxJoCh1Bc3NpZ25H",
-            "dWVzdE93bmVyVG9UcmFuc2FjdGlvbhIvLmhvbG1zLnR5cGVzLm1vbmV5LnJw",
-            "Yy5Bc3NpZ25HdWVzdE93bmVyVG9UeG5SZXEaFi5nb29nbGUucHJvdG9idWYu",
-            "RW1wdHkSZQoSR2V0RXhwb3J0Sm9iU3RhdHVzEhYuZ29vZ2xlLnByb3RvYnVm",
-            "LkVtcHR5GjcuaG9sbXMudHlwZXMubW9uZXkuYWNjb3VudGluZy5BY2NvdW50",
-            "aW5nVHhuRXhwb3J0U3RhdHVzEk0KF1VwZGF0ZUxhc3RFeHBvcnRSdW5UaW1l",
-            "EhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcBoWLmdvb2dsZS5wcm90b2J1",
-            "Zi5FbXB0eRLGAQofR2V0UHJvcGVydHlUcmFuc2FjdGlvbnNJbkZvcm1hdBJQ",
-            "LmhvbG1zLnR5cGVzLm1vbmV5LnJwYy5BY2NvdW50VHhuRXhwb3J0U3ZjR2V0",
-            "UHJvcGVydHlUcmFuc2FjdGlvbnNJbkZvcm1hdFJlcXVlc3QaUS5ob2xtcy50",
-            "eXBlcy5tb25leS5ycGMuQWNjb3VudFR4bkV4cG9ydFN2Y0dldFByb3BlcnR5",
-            "VHJhbnNhY3Rpb25zSW5Gb3JtYXRSZXNwb25zZUIjWgltb25leS9ycGOqAhVI",
-            "T0xNUy5UeXBlcy5Nb25leS5SUENiBnByb3RvMw=="));
+            "eXBlcy5tb25leS5ycGMaG2dvb2dsZS9wcm90b2J1Zi9lbXB0eS5wcm90bxow",
+            "cHJpbWl0aXZlL3BiX2luY2x1c2l2ZV9jYWxlbmRhcl9kYXRlX3JhbmdlLnBy",
+            "b3RvGiBjcm0vZ3Vlc3RzL2d1ZXN0X2luZGljYXRvci5wcm90bxo7bW9uZXkv",
+            "YWNjb3VudGluZy9hY2NvdW50aW5nX3RyYW5zYWN0aW9uX2V4cG9ydF9mb3Jt",
+            "YXQucHJvdG8aM21vbmV5L2FjY291bnRpbmcvYWNjb3VudGluZ190eG5fZXhw",
+            "b3J0X3N0YXR1cy5wcm90bxo4bW9uZXkvYWNjb3VudGluZy9hY2NvdW50aW5n",
+            "X3RyYW5zYWN0aW9uX3dpdGhfZ3Vlc3QucHJvdG8iugEKGEFzc2lnbkd1ZXN0",
+            "T3duZXJUb1R4blJlcRJnCiFhY2NvdW50aW5nX3RyYW5zYWN0aW9uX3dpdGhf",
+            "Z3Vlc3QYASABKAsyPC5ob2xtcy50eXBlcy5tb25leS5hY2NvdW50aW5nLkFj",
+            "Y291bnRpbmdUcmFuc2FjdGlvbldpdGhHdWVzdBI1CgVndWVzdBgCIAEoCzIm",
+            "LmhvbG1zLnR5cGVzLmNybS5ndWVzdHMuR3Vlc3RJbmRpY2F0b3Ii2AEKPEFj",
+            "Y291bnRUeG5FeHBvcnRTdmNVcGxvYWRQcm9wZXJ0eVRyYW5zYWN0aW9uc0lu",
+            "Rm9ybWF0UmVxdWVzdBJPCgZmb3JtYXQYASABKA4yPy5ob2xtcy50eXBlcy5t",
+            "b25leS5hY2NvdW50aW5nLkFjY291bnRpbmdUcmFuc2FjdGlvbkV4cG9ydEZv",
+            "cm1hdBJHCgpkYXRlX3JhbmdlGAMgASgLMjMuaG9sbXMudHlwZXMucHJpbWl0",
+            "aXZlLlBiSW5jbHVzaXZlQ2FsZW5kYXJEYXRlUmFuZ2Uy9wIKEEFjY291bnRp",
+            "bmdUeG5TdmMSaAodQXNzaWduR3Vlc3RPd25lclRvVHJhbnNhY3Rpb24SLy5o",
+            "b2xtcy50eXBlcy5tb25leS5ycGMuQXNzaWduR3Vlc3RPd25lclRvVHhuUmVx",
+            "GhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5EmUKEkdldEV4cG9ydEpvYlN0YXR1",
+            "cxIWLmdvb2dsZS5wcm90b2J1Zi5FbXB0eRo3LmhvbG1zLnR5cGVzLm1vbmV5",
+            "LmFjY291bnRpbmcuQWNjb3VudGluZ1R4bkV4cG9ydFN0YXR1cxKRAQoiVXBs",
+            "b2FkUHJvcGVydHlUcmFuc2FjdGlvbnNJbkZvcm1hdBJTLmhvbG1zLnR5cGVz",
+            "Lm1vbmV5LnJwYy5BY2NvdW50VHhuRXhwb3J0U3ZjVXBsb2FkUHJvcGVydHlU",
+            "cmFuc2FjdGlvbnNJbkZvcm1hdFJlcXVlc3QaFi5nb29nbGUucHJvdG9idWYu",
+            "RW1wdHlCI1oJbW9uZXkvcnBjqgIVSE9MTVMuVHlwZXMuTW9uZXkuUlBDYgZw",
+            "cm90bzM="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
-          new pbr::FileDescriptor[] { global::Google.Protobuf.WellKnownTypes.EmptyReflection.Descriptor, global::Google.Protobuf.WellKnownTypes.TimestampReflection.Descriptor, global::HOLMS.Types.Primitive.PbInclusiveCalendarDateRangeReflection.Descriptor, global::HOLMS.Types.CRM.Guests.GuestIndicatorReflection.Descriptor, global::HOLMS.Types.Money.Accounting.AccountingTransactionExportFormatReflection.Descriptor, global::HOLMS.Types.Money.Accounting.AccountingTxnExportStatusReflection.Descriptor, global::HOLMS.Types.Money.Accounting.AccountingTransactionWithGuestReflection.Descriptor, global::HOLMS.Types.TenancyConfig.Indicators.PropertyIndicatorReflection.Descriptor, },
+          new pbr::FileDescriptor[] { global::Google.Protobuf.WellKnownTypes.EmptyReflection.Descriptor, global::HOLMS.Types.Primitive.PbInclusiveCalendarDateRangeReflection.Descriptor, global::HOLMS.Types.CRM.Guests.GuestIndicatorReflection.Descriptor, global::HOLMS.Types.Money.Accounting.AccountingTransactionExportFormatReflection.Descriptor, global::HOLMS.Types.Money.Accounting.AccountingTxnExportStatusReflection.Descriptor, global::HOLMS.Types.Money.Accounting.AccountingTransactionWithGuestReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {
             new pbr::GeneratedClrTypeInfo(typeof(global::HOLMS.Types.Money.RPC.AssignGuestOwnerToTxnReq), global::HOLMS.Types.Money.RPC.AssignGuestOwnerToTxnReq.Parser, new[]{ "AccountingTransactionWithGuest", "Guest" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::HOLMS.Types.Money.RPC.AccountTxnExportSvcGetPropertyTransactionsInFormatRequest), global::HOLMS.Types.Money.RPC.AccountTxnExportSvcGetPropertyTransactionsInFormatRequest.Parser, new[]{ "Format", "Property", "DateRange" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::HOLMS.Types.Money.RPC.AccountTxnExportSvcGetPropertyTransactionsInFormatResponse), global::HOLMS.Types.Money.RPC.AccountTxnExportSvcGetPropertyTransactionsInFormatResponse.Parser, new[]{ "ExportedTransactions" }, null, null, null)
+            new pbr::GeneratedClrTypeInfo(typeof(global::HOLMS.Types.Money.RPC.AccountTxnExportSvcUploadPropertyTransactionsInFormatRequest), global::HOLMS.Types.Money.RPC.AccountTxnExportSvcUploadPropertyTransactionsInFormatRequest.Parser, new[]{ "Format", "DateRange" }, null, null, null)
           }));
     }
     #endregion
@@ -226,10 +217,10 @@ namespace HOLMS.Types.Money.RPC {
 
   }
 
-  public sealed partial class AccountTxnExportSvcGetPropertyTransactionsInFormatRequest : pb::IMessage<AccountTxnExportSvcGetPropertyTransactionsInFormatRequest> {
-    private static readonly pb::MessageParser<AccountTxnExportSvcGetPropertyTransactionsInFormatRequest> _parser = new pb::MessageParser<AccountTxnExportSvcGetPropertyTransactionsInFormatRequest>(() => new AccountTxnExportSvcGetPropertyTransactionsInFormatRequest());
+  public sealed partial class AccountTxnExportSvcUploadPropertyTransactionsInFormatRequest : pb::IMessage<AccountTxnExportSvcUploadPropertyTransactionsInFormatRequest> {
+    private static readonly pb::MessageParser<AccountTxnExportSvcUploadPropertyTransactionsInFormatRequest> _parser = new pb::MessageParser<AccountTxnExportSvcUploadPropertyTransactionsInFormatRequest>(() => new AccountTxnExportSvcUploadPropertyTransactionsInFormatRequest());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public static pb::MessageParser<AccountTxnExportSvcGetPropertyTransactionsInFormatRequest> Parser { get { return _parser; } }
+    public static pb::MessageParser<AccountTxnExportSvcUploadPropertyTransactionsInFormatRequest> Parser { get { return _parser; } }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
@@ -242,22 +233,21 @@ namespace HOLMS.Types.Money.RPC {
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public AccountTxnExportSvcGetPropertyTransactionsInFormatRequest() {
+    public AccountTxnExportSvcUploadPropertyTransactionsInFormatRequest() {
       OnConstruction();
     }
 
     partial void OnConstruction();
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public AccountTxnExportSvcGetPropertyTransactionsInFormatRequest(AccountTxnExportSvcGetPropertyTransactionsInFormatRequest other) : this() {
+    public AccountTxnExportSvcUploadPropertyTransactionsInFormatRequest(AccountTxnExportSvcUploadPropertyTransactionsInFormatRequest other) : this() {
       format_ = other.format_;
-      Property = other.property_ != null ? other.Property.Clone() : null;
       DateRange = other.dateRange_ != null ? other.DateRange.Clone() : null;
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public AccountTxnExportSvcGetPropertyTransactionsInFormatRequest Clone() {
-      return new AccountTxnExportSvcGetPropertyTransactionsInFormatRequest(this);
+    public AccountTxnExportSvcUploadPropertyTransactionsInFormatRequest Clone() {
+      return new AccountTxnExportSvcUploadPropertyTransactionsInFormatRequest(this);
     }
 
     /// <summary>Field number for the "format" field.</summary>
@@ -268,17 +258,6 @@ namespace HOLMS.Types.Money.RPC {
       get { return format_; }
       set {
         format_ = value;
-      }
-    }
-
-    /// <summary>Field number for the "property" field.</summary>
-    public const int PropertyFieldNumber = 2;
-    private global::HOLMS.Types.TenancyConfig.Indicators.PropertyIndicator property_;
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::HOLMS.Types.TenancyConfig.Indicators.PropertyIndicator Property {
-      get { return property_; }
-      set {
-        property_ = value;
       }
     }
 
@@ -295,11 +274,11 @@ namespace HOLMS.Types.Money.RPC {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
-      return Equals(other as AccountTxnExportSvcGetPropertyTransactionsInFormatRequest);
+      return Equals(other as AccountTxnExportSvcUploadPropertyTransactionsInFormatRequest);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool Equals(AccountTxnExportSvcGetPropertyTransactionsInFormatRequest other) {
+    public bool Equals(AccountTxnExportSvcUploadPropertyTransactionsInFormatRequest other) {
       if (ReferenceEquals(other, null)) {
         return false;
       }
@@ -307,7 +286,6 @@ namespace HOLMS.Types.Money.RPC {
         return true;
       }
       if (Format != other.Format) return false;
-      if (!object.Equals(Property, other.Property)) return false;
       if (!object.Equals(DateRange, other.DateRange)) return false;
       return true;
     }
@@ -316,7 +294,6 @@ namespace HOLMS.Types.Money.RPC {
     public override int GetHashCode() {
       int hash = 1;
       if (Format != 0) hash ^= Format.GetHashCode();
-      if (property_ != null) hash ^= Property.GetHashCode();
       if (dateRange_ != null) hash ^= DateRange.GetHashCode();
       return hash;
     }
@@ -332,10 +309,6 @@ namespace HOLMS.Types.Money.RPC {
         output.WriteRawTag(8);
         output.WriteEnum((int) Format);
       }
-      if (property_ != null) {
-        output.WriteRawTag(18);
-        output.WriteMessage(Property);
-      }
       if (dateRange_ != null) {
         output.WriteRawTag(26);
         output.WriteMessage(DateRange);
@@ -348,9 +321,6 @@ namespace HOLMS.Types.Money.RPC {
       if (Format != 0) {
         size += 1 + pb::CodedOutputStream.ComputeEnumSize((int) Format);
       }
-      if (property_ != null) {
-        size += 1 + pb::CodedOutputStream.ComputeMessageSize(Property);
-      }
       if (dateRange_ != null) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(DateRange);
       }
@@ -358,18 +328,12 @@ namespace HOLMS.Types.Money.RPC {
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void MergeFrom(AccountTxnExportSvcGetPropertyTransactionsInFormatRequest other) {
+    public void MergeFrom(AccountTxnExportSvcUploadPropertyTransactionsInFormatRequest other) {
       if (other == null) {
         return;
       }
       if (other.Format != 0) {
         Format = other.Format;
-      }
-      if (other.property_ != null) {
-        if (property_ == null) {
-          property_ = new global::HOLMS.Types.TenancyConfig.Indicators.PropertyIndicator();
-        }
-        Property.MergeFrom(other.Property);
       }
       if (other.dateRange_ != null) {
         if (dateRange_ == null) {
@@ -391,135 +355,11 @@ namespace HOLMS.Types.Money.RPC {
             format_ = (global::HOLMS.Types.Money.Accounting.AccountingTransactionExportFormat) input.ReadEnum();
             break;
           }
-          case 18: {
-            if (property_ == null) {
-              property_ = new global::HOLMS.Types.TenancyConfig.Indicators.PropertyIndicator();
-            }
-            input.ReadMessage(property_);
-            break;
-          }
           case 26: {
             if (dateRange_ == null) {
               dateRange_ = new global::HOLMS.Types.Primitive.PbInclusiveCalendarDateRange();
             }
             input.ReadMessage(dateRange_);
-            break;
-          }
-        }
-      }
-    }
-
-  }
-
-  public sealed partial class AccountTxnExportSvcGetPropertyTransactionsInFormatResponse : pb::IMessage<AccountTxnExportSvcGetPropertyTransactionsInFormatResponse> {
-    private static readonly pb::MessageParser<AccountTxnExportSvcGetPropertyTransactionsInFormatResponse> _parser = new pb::MessageParser<AccountTxnExportSvcGetPropertyTransactionsInFormatResponse>(() => new AccountTxnExportSvcGetPropertyTransactionsInFormatResponse());
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public static pb::MessageParser<AccountTxnExportSvcGetPropertyTransactionsInFormatResponse> Parser { get { return _parser; } }
-
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public static pbr::MessageDescriptor Descriptor {
-      get { return global::HOLMS.Types.Money.RPC.AccountingTxnSvcReflection.Descriptor.MessageTypes[2]; }
-    }
-
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
-      get { return Descriptor; }
-    }
-
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public AccountTxnExportSvcGetPropertyTransactionsInFormatResponse() {
-      OnConstruction();
-    }
-
-    partial void OnConstruction();
-
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public AccountTxnExportSvcGetPropertyTransactionsInFormatResponse(AccountTxnExportSvcGetPropertyTransactionsInFormatResponse other) : this() {
-      exportedTransactions_ = other.exportedTransactions_;
-    }
-
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public AccountTxnExportSvcGetPropertyTransactionsInFormatResponse Clone() {
-      return new AccountTxnExportSvcGetPropertyTransactionsInFormatResponse(this);
-    }
-
-    /// <summary>Field number for the "exported_transactions" field.</summary>
-    public const int ExportedTransactionsFieldNumber = 1;
-    private pb::ByteString exportedTransactions_ = pb::ByteString.Empty;
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public pb::ByteString ExportedTransactions {
-      get { return exportedTransactions_; }
-      set {
-        exportedTransactions_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
-      }
-    }
-
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public override bool Equals(object other) {
-      return Equals(other as AccountTxnExportSvcGetPropertyTransactionsInFormatResponse);
-    }
-
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool Equals(AccountTxnExportSvcGetPropertyTransactionsInFormatResponse other) {
-      if (ReferenceEquals(other, null)) {
-        return false;
-      }
-      if (ReferenceEquals(other, this)) {
-        return true;
-      }
-      if (ExportedTransactions != other.ExportedTransactions) return false;
-      return true;
-    }
-
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public override int GetHashCode() {
-      int hash = 1;
-      if (ExportedTransactions.Length != 0) hash ^= ExportedTransactions.GetHashCode();
-      return hash;
-    }
-
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public override string ToString() {
-      return pb::JsonFormatter.ToDiagnosticString(this);
-    }
-
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void WriteTo(pb::CodedOutputStream output) {
-      if (ExportedTransactions.Length != 0) {
-        output.WriteRawTag(10);
-        output.WriteBytes(ExportedTransactions);
-      }
-    }
-
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public int CalculateSize() {
-      int size = 0;
-      if (ExportedTransactions.Length != 0) {
-        size += 1 + pb::CodedOutputStream.ComputeBytesSize(ExportedTransactions);
-      }
-      return size;
-    }
-
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void MergeFrom(AccountTxnExportSvcGetPropertyTransactionsInFormatResponse other) {
-      if (other == null) {
-        return;
-      }
-      if (other.ExportedTransactions.Length != 0) {
-        ExportedTransactions = other.ExportedTransactions;
-      }
-    }
-
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void MergeFrom(pb::CodedInputStream input) {
-      uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
-          default:
-            input.SkipLastField();
-            break;
-          case 10: {
-            ExportedTransactions = input.ReadBytes();
             break;
           }
         }

--- a/csharp/HOLMS.Platform/HOLMS.Platform/Types/out/AccountingTxnSvc.cs
+++ b/csharp/HOLMS.Platform/HOLMS.Platform/Types/out/AccountingTxnSvc.cs
@@ -33,27 +33,27 @@ namespace HOLMS.Types.Money.RPC {
             "T3duZXJUb1R4blJlcRJnCiFhY2NvdW50aW5nX3RyYW5zYWN0aW9uX3dpdGhf",
             "Z3Vlc3QYASABKAsyPC5ob2xtcy50eXBlcy5tb25leS5hY2NvdW50aW5nLkFj",
             "Y291bnRpbmdUcmFuc2FjdGlvbldpdGhHdWVzdBI1CgVndWVzdBgCIAEoCzIm",
-            "LmhvbG1zLnR5cGVzLmNybS5ndWVzdHMuR3Vlc3RJbmRpY2F0b3Ii2AEKPEFj",
+            "LmhvbG1zLnR5cGVzLmNybS5ndWVzdHMuR3Vlc3RJbmRpY2F0b3Ii9gEKPEFj",
             "Y291bnRUeG5FeHBvcnRTdmNVcGxvYWRQcm9wZXJ0eVRyYW5zYWN0aW9uc0lu",
             "Rm9ybWF0UmVxdWVzdBJPCgZmb3JtYXQYASABKA4yPy5ob2xtcy50eXBlcy5t",
             "b25leS5hY2NvdW50aW5nLkFjY291bnRpbmdUcmFuc2FjdGlvbkV4cG9ydEZv",
             "cm1hdBJHCgpkYXRlX3JhbmdlGAMgASgLMjMuaG9sbXMudHlwZXMucHJpbWl0",
-            "aXZlLlBiSW5jbHVzaXZlQ2FsZW5kYXJEYXRlUmFuZ2Uy9wIKEEFjY291bnRp",
-            "bmdUeG5TdmMSaAodQXNzaWduR3Vlc3RPd25lclRvVHJhbnNhY3Rpb24SLy5o",
-            "b2xtcy50eXBlcy5tb25leS5ycGMuQXNzaWduR3Vlc3RPd25lclRvVHhuUmVx",
-            "GhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5EmUKEkdldEV4cG9ydEpvYlN0YXR1",
-            "cxIWLmdvb2dsZS5wcm90b2J1Zi5FbXB0eRo3LmhvbG1zLnR5cGVzLm1vbmV5",
-            "LmFjY291bnRpbmcuQWNjb3VudGluZ1R4bkV4cG9ydFN0YXR1cxKRAQoiVXBs",
-            "b2FkUHJvcGVydHlUcmFuc2FjdGlvbnNJbkZvcm1hdBJTLmhvbG1zLnR5cGVz",
-            "Lm1vbmV5LnJwYy5BY2NvdW50VHhuRXhwb3J0U3ZjVXBsb2FkUHJvcGVydHlU",
-            "cmFuc2FjdGlvbnNJbkZvcm1hdFJlcXVlc3QaFi5nb29nbGUucHJvdG9idWYu",
-            "RW1wdHlCI1oJbW9uZXkvcnBjqgIVSE9MTVMuVHlwZXMuTW9uZXkuUlBDYgZw",
-            "cm90bzM="));
+            "aXZlLlBiSW5jbHVzaXZlQ2FsZW5kYXJEYXRlUmFuZ2USHAoUdXBkYXRlX2xh",
+            "c3RfcnVuX2RhdGUYBCABKAgy9wIKEEFjY291bnRpbmdUeG5TdmMSaAodQXNz",
+            "aWduR3Vlc3RPd25lclRvVHJhbnNhY3Rpb24SLy5ob2xtcy50eXBlcy5tb25l",
+            "eS5ycGMuQXNzaWduR3Vlc3RPd25lclRvVHhuUmVxGhYuZ29vZ2xlLnByb3Rv",
+            "YnVmLkVtcHR5EmUKEkdldEV4cG9ydEpvYlN0YXR1cxIWLmdvb2dsZS5wcm90",
+            "b2J1Zi5FbXB0eRo3LmhvbG1zLnR5cGVzLm1vbmV5LmFjY291bnRpbmcuQWNj",
+            "b3VudGluZ1R4bkV4cG9ydFN0YXR1cxKRAQoiVXBsb2FkUHJvcGVydHlUcmFu",
+            "c2FjdGlvbnNJbkZvcm1hdBJTLmhvbG1zLnR5cGVzLm1vbmV5LnJwYy5BY2Nv",
+            "dW50VHhuRXhwb3J0U3ZjVXBsb2FkUHJvcGVydHlUcmFuc2FjdGlvbnNJbkZv",
+            "cm1hdFJlcXVlc3QaFi5nb29nbGUucHJvdG9idWYuRW1wdHlCI1oJbW9uZXkv",
+            "cnBjqgIVSE9MTVMuVHlwZXMuTW9uZXkuUlBDYgZwcm90bzM="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::Google.Protobuf.WellKnownTypes.EmptyReflection.Descriptor, global::HOLMS.Types.Primitive.PbInclusiveCalendarDateRangeReflection.Descriptor, global::HOLMS.Types.CRM.Guests.GuestIndicatorReflection.Descriptor, global::HOLMS.Types.Money.Accounting.AccountingTransactionExportFormatReflection.Descriptor, global::HOLMS.Types.Money.Accounting.AccountingTxnExportStatusReflection.Descriptor, global::HOLMS.Types.Money.Accounting.AccountingTransactionWithGuestReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {
             new pbr::GeneratedClrTypeInfo(typeof(global::HOLMS.Types.Money.RPC.AssignGuestOwnerToTxnReq), global::HOLMS.Types.Money.RPC.AssignGuestOwnerToTxnReq.Parser, new[]{ "AccountingTransactionWithGuest", "Guest" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::HOLMS.Types.Money.RPC.AccountTxnExportSvcUploadPropertyTransactionsInFormatRequest), global::HOLMS.Types.Money.RPC.AccountTxnExportSvcUploadPropertyTransactionsInFormatRequest.Parser, new[]{ "Format", "DateRange" }, null, null, null)
+            new pbr::GeneratedClrTypeInfo(typeof(global::HOLMS.Types.Money.RPC.AccountTxnExportSvcUploadPropertyTransactionsInFormatRequest), global::HOLMS.Types.Money.RPC.AccountTxnExportSvcUploadPropertyTransactionsInFormatRequest.Parser, new[]{ "Format", "DateRange", "UpdateLastRunDate" }, null, null, null)
           }));
     }
     #endregion
@@ -243,6 +243,7 @@ namespace HOLMS.Types.Money.RPC {
     public AccountTxnExportSvcUploadPropertyTransactionsInFormatRequest(AccountTxnExportSvcUploadPropertyTransactionsInFormatRequest other) : this() {
       format_ = other.format_;
       DateRange = other.dateRange_ != null ? other.DateRange.Clone() : null;
+      updateLastRunDate_ = other.updateLastRunDate_;
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -264,11 +265,25 @@ namespace HOLMS.Types.Money.RPC {
     /// <summary>Field number for the "date_range" field.</summary>
     public const int DateRangeFieldNumber = 3;
     private global::HOLMS.Types.Primitive.PbInclusiveCalendarDateRange dateRange_;
+    /// <summary>
+    ///  .holms.types.tenancy_config.indicators.PropertyIndicator property = 2;
+    /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public global::HOLMS.Types.Primitive.PbInclusiveCalendarDateRange DateRange {
       get { return dateRange_; }
       set {
         dateRange_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "update_last_run_date" field.</summary>
+    public const int UpdateLastRunDateFieldNumber = 4;
+    private bool updateLastRunDate_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public bool UpdateLastRunDate {
+      get { return updateLastRunDate_; }
+      set {
+        updateLastRunDate_ = value;
       }
     }
 
@@ -287,6 +302,7 @@ namespace HOLMS.Types.Money.RPC {
       }
       if (Format != other.Format) return false;
       if (!object.Equals(DateRange, other.DateRange)) return false;
+      if (UpdateLastRunDate != other.UpdateLastRunDate) return false;
       return true;
     }
 
@@ -295,6 +311,7 @@ namespace HOLMS.Types.Money.RPC {
       int hash = 1;
       if (Format != 0) hash ^= Format.GetHashCode();
       if (dateRange_ != null) hash ^= DateRange.GetHashCode();
+      if (UpdateLastRunDate != false) hash ^= UpdateLastRunDate.GetHashCode();
       return hash;
     }
 
@@ -313,6 +330,10 @@ namespace HOLMS.Types.Money.RPC {
         output.WriteRawTag(26);
         output.WriteMessage(DateRange);
       }
+      if (UpdateLastRunDate != false) {
+        output.WriteRawTag(32);
+        output.WriteBool(UpdateLastRunDate);
+      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -323,6 +344,9 @@ namespace HOLMS.Types.Money.RPC {
       }
       if (dateRange_ != null) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(DateRange);
+      }
+      if (UpdateLastRunDate != false) {
+        size += 1 + 1;
       }
       return size;
     }
@@ -340,6 +364,9 @@ namespace HOLMS.Types.Money.RPC {
           dateRange_ = new global::HOLMS.Types.Primitive.PbInclusiveCalendarDateRange();
         }
         DateRange.MergeFrom(other.DateRange);
+      }
+      if (other.UpdateLastRunDate != false) {
+        UpdateLastRunDate = other.UpdateLastRunDate;
       }
     }
 
@@ -360,6 +387,10 @@ namespace HOLMS.Types.Money.RPC {
               dateRange_ = new global::HOLMS.Types.Primitive.PbInclusiveCalendarDateRange();
             }
             input.ReadMessage(dateRange_);
+            break;
+          }
+          case 32: {
+            UpdateLastRunDate = input.ReadBool();
             break;
           }
         }

--- a/csharp/HOLMS.Platform/HOLMS.Platform/Types/out/AccountingTxnSvcGrpc.cs
+++ b/csharp/HOLMS.Platform/HOLMS.Platform/Types/out/AccountingTxnSvcGrpc.cs
@@ -15,9 +15,7 @@ namespace HOLMS.Types.Money.RPC {
     static readonly Marshaller<global::HOLMS.Types.Money.RPC.AssignGuestOwnerToTxnReq> __Marshaller_AssignGuestOwnerToTxnReq = Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::HOLMS.Types.Money.RPC.AssignGuestOwnerToTxnReq.Parser.ParseFrom);
     static readonly Marshaller<global::Google.Protobuf.WellKnownTypes.Empty> __Marshaller_Empty = Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::Google.Protobuf.WellKnownTypes.Empty.Parser.ParseFrom);
     static readonly Marshaller<global::HOLMS.Types.Money.Accounting.AccountingTxnExportStatus> __Marshaller_AccountingTxnExportStatus = Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::HOLMS.Types.Money.Accounting.AccountingTxnExportStatus.Parser.ParseFrom);
-    static readonly Marshaller<global::Google.Protobuf.WellKnownTypes.Timestamp> __Marshaller_Timestamp = Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::Google.Protobuf.WellKnownTypes.Timestamp.Parser.ParseFrom);
-    static readonly Marshaller<global::HOLMS.Types.Money.RPC.AccountTxnExportSvcGetPropertyTransactionsInFormatRequest> __Marshaller_AccountTxnExportSvcGetPropertyTransactionsInFormatRequest = Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::HOLMS.Types.Money.RPC.AccountTxnExportSvcGetPropertyTransactionsInFormatRequest.Parser.ParseFrom);
-    static readonly Marshaller<global::HOLMS.Types.Money.RPC.AccountTxnExportSvcGetPropertyTransactionsInFormatResponse> __Marshaller_AccountTxnExportSvcGetPropertyTransactionsInFormatResponse = Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::HOLMS.Types.Money.RPC.AccountTxnExportSvcGetPropertyTransactionsInFormatResponse.Parser.ParseFrom);
+    static readonly Marshaller<global::HOLMS.Types.Money.RPC.AccountTxnExportSvcUploadPropertyTransactionsInFormatRequest> __Marshaller_AccountTxnExportSvcUploadPropertyTransactionsInFormatRequest = Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::HOLMS.Types.Money.RPC.AccountTxnExportSvcUploadPropertyTransactionsInFormatRequest.Parser.ParseFrom);
 
     static readonly Method<global::HOLMS.Types.Money.RPC.AssignGuestOwnerToTxnReq, global::Google.Protobuf.WellKnownTypes.Empty> __Method_AssignGuestOwnerToTransaction = new Method<global::HOLMS.Types.Money.RPC.AssignGuestOwnerToTxnReq, global::Google.Protobuf.WellKnownTypes.Empty>(
         MethodType.Unary,
@@ -33,19 +31,12 @@ namespace HOLMS.Types.Money.RPC {
         __Marshaller_Empty,
         __Marshaller_AccountingTxnExportStatus);
 
-    static readonly Method<global::Google.Protobuf.WellKnownTypes.Timestamp, global::Google.Protobuf.WellKnownTypes.Empty> __Method_UpdateLastExportRunTime = new Method<global::Google.Protobuf.WellKnownTypes.Timestamp, global::Google.Protobuf.WellKnownTypes.Empty>(
+    static readonly Method<global::HOLMS.Types.Money.RPC.AccountTxnExportSvcUploadPropertyTransactionsInFormatRequest, global::Google.Protobuf.WellKnownTypes.Empty> __Method_UploadPropertyTransactionsInFormat = new Method<global::HOLMS.Types.Money.RPC.AccountTxnExportSvcUploadPropertyTransactionsInFormatRequest, global::Google.Protobuf.WellKnownTypes.Empty>(
         MethodType.Unary,
         __ServiceName,
-        "UpdateLastExportRunTime",
-        __Marshaller_Timestamp,
+        "UploadPropertyTransactionsInFormat",
+        __Marshaller_AccountTxnExportSvcUploadPropertyTransactionsInFormatRequest,
         __Marshaller_Empty);
-
-    static readonly Method<global::HOLMS.Types.Money.RPC.AccountTxnExportSvcGetPropertyTransactionsInFormatRequest, global::HOLMS.Types.Money.RPC.AccountTxnExportSvcGetPropertyTransactionsInFormatResponse> __Method_GetPropertyTransactionsInFormat = new Method<global::HOLMS.Types.Money.RPC.AccountTxnExportSvcGetPropertyTransactionsInFormatRequest, global::HOLMS.Types.Money.RPC.AccountTxnExportSvcGetPropertyTransactionsInFormatResponse>(
-        MethodType.Unary,
-        __ServiceName,
-        "GetPropertyTransactionsInFormat",
-        __Marshaller_AccountTxnExportSvcGetPropertyTransactionsInFormatRequest,
-        __Marshaller_AccountTxnExportSvcGetPropertyTransactionsInFormatResponse);
 
     /// <summary>Service descriptor</summary>
     public static global::Google.Protobuf.Reflection.ServiceDescriptor Descriptor
@@ -66,12 +57,7 @@ namespace HOLMS.Types.Money.RPC {
         throw new RpcException(new Status(StatusCode.Unimplemented, ""));
       }
 
-      public virtual global::System.Threading.Tasks.Task<global::Google.Protobuf.WellKnownTypes.Empty> UpdateLastExportRunTime(global::Google.Protobuf.WellKnownTypes.Timestamp request, ServerCallContext context)
-      {
-        throw new RpcException(new Status(StatusCode.Unimplemented, ""));
-      }
-
-      public virtual global::System.Threading.Tasks.Task<global::HOLMS.Types.Money.RPC.AccountTxnExportSvcGetPropertyTransactionsInFormatResponse> GetPropertyTransactionsInFormat(global::HOLMS.Types.Money.RPC.AccountTxnExportSvcGetPropertyTransactionsInFormatRequest request, ServerCallContext context)
+      public virtual global::System.Threading.Tasks.Task<global::Google.Protobuf.WellKnownTypes.Empty> UploadPropertyTransactionsInFormat(global::HOLMS.Types.Money.RPC.AccountTxnExportSvcUploadPropertyTransactionsInFormatRequest request, ServerCallContext context)
       {
         throw new RpcException(new Status(StatusCode.Unimplemented, ""));
       }
@@ -133,37 +119,21 @@ namespace HOLMS.Types.Money.RPC {
       {
         return CallInvoker.AsyncUnaryCall(__Method_GetExportJobStatus, null, options, request);
       }
-      public virtual global::Google.Protobuf.WellKnownTypes.Empty UpdateLastExportRunTime(global::Google.Protobuf.WellKnownTypes.Timestamp request, Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken))
+      public virtual global::Google.Protobuf.WellKnownTypes.Empty UploadPropertyTransactionsInFormat(global::HOLMS.Types.Money.RPC.AccountTxnExportSvcUploadPropertyTransactionsInFormatRequest request, Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken))
       {
-        return UpdateLastExportRunTime(request, new CallOptions(headers, deadline, cancellationToken));
+        return UploadPropertyTransactionsInFormat(request, new CallOptions(headers, deadline, cancellationToken));
       }
-      public virtual global::Google.Protobuf.WellKnownTypes.Empty UpdateLastExportRunTime(global::Google.Protobuf.WellKnownTypes.Timestamp request, CallOptions options)
+      public virtual global::Google.Protobuf.WellKnownTypes.Empty UploadPropertyTransactionsInFormat(global::HOLMS.Types.Money.RPC.AccountTxnExportSvcUploadPropertyTransactionsInFormatRequest request, CallOptions options)
       {
-        return CallInvoker.BlockingUnaryCall(__Method_UpdateLastExportRunTime, null, options, request);
+        return CallInvoker.BlockingUnaryCall(__Method_UploadPropertyTransactionsInFormat, null, options, request);
       }
-      public virtual AsyncUnaryCall<global::Google.Protobuf.WellKnownTypes.Empty> UpdateLastExportRunTimeAsync(global::Google.Protobuf.WellKnownTypes.Timestamp request, Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken))
+      public virtual AsyncUnaryCall<global::Google.Protobuf.WellKnownTypes.Empty> UploadPropertyTransactionsInFormatAsync(global::HOLMS.Types.Money.RPC.AccountTxnExportSvcUploadPropertyTransactionsInFormatRequest request, Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken))
       {
-        return UpdateLastExportRunTimeAsync(request, new CallOptions(headers, deadline, cancellationToken));
+        return UploadPropertyTransactionsInFormatAsync(request, new CallOptions(headers, deadline, cancellationToken));
       }
-      public virtual AsyncUnaryCall<global::Google.Protobuf.WellKnownTypes.Empty> UpdateLastExportRunTimeAsync(global::Google.Protobuf.WellKnownTypes.Timestamp request, CallOptions options)
+      public virtual AsyncUnaryCall<global::Google.Protobuf.WellKnownTypes.Empty> UploadPropertyTransactionsInFormatAsync(global::HOLMS.Types.Money.RPC.AccountTxnExportSvcUploadPropertyTransactionsInFormatRequest request, CallOptions options)
       {
-        return CallInvoker.AsyncUnaryCall(__Method_UpdateLastExportRunTime, null, options, request);
-      }
-      public virtual global::HOLMS.Types.Money.RPC.AccountTxnExportSvcGetPropertyTransactionsInFormatResponse GetPropertyTransactionsInFormat(global::HOLMS.Types.Money.RPC.AccountTxnExportSvcGetPropertyTransactionsInFormatRequest request, Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken))
-      {
-        return GetPropertyTransactionsInFormat(request, new CallOptions(headers, deadline, cancellationToken));
-      }
-      public virtual global::HOLMS.Types.Money.RPC.AccountTxnExportSvcGetPropertyTransactionsInFormatResponse GetPropertyTransactionsInFormat(global::HOLMS.Types.Money.RPC.AccountTxnExportSvcGetPropertyTransactionsInFormatRequest request, CallOptions options)
-      {
-        return CallInvoker.BlockingUnaryCall(__Method_GetPropertyTransactionsInFormat, null, options, request);
-      }
-      public virtual AsyncUnaryCall<global::HOLMS.Types.Money.RPC.AccountTxnExportSvcGetPropertyTransactionsInFormatResponse> GetPropertyTransactionsInFormatAsync(global::HOLMS.Types.Money.RPC.AccountTxnExportSvcGetPropertyTransactionsInFormatRequest request, Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken))
-      {
-        return GetPropertyTransactionsInFormatAsync(request, new CallOptions(headers, deadline, cancellationToken));
-      }
-      public virtual AsyncUnaryCall<global::HOLMS.Types.Money.RPC.AccountTxnExportSvcGetPropertyTransactionsInFormatResponse> GetPropertyTransactionsInFormatAsync(global::HOLMS.Types.Money.RPC.AccountTxnExportSvcGetPropertyTransactionsInFormatRequest request, CallOptions options)
-      {
-        return CallInvoker.AsyncUnaryCall(__Method_GetPropertyTransactionsInFormat, null, options, request);
+        return CallInvoker.AsyncUnaryCall(__Method_UploadPropertyTransactionsInFormat, null, options, request);
       }
       protected override AccountingTxnSvcClient NewInstance(ClientBaseConfiguration configuration)
       {
@@ -177,8 +147,7 @@ namespace HOLMS.Types.Money.RPC {
       return ServerServiceDefinition.CreateBuilder()
           .AddMethod(__Method_AssignGuestOwnerToTransaction, serviceImpl.AssignGuestOwnerToTransaction)
           .AddMethod(__Method_GetExportJobStatus, serviceImpl.GetExportJobStatus)
-          .AddMethod(__Method_UpdateLastExportRunTime, serviceImpl.UpdateLastExportRunTime)
-          .AddMethod(__Method_GetPropertyTransactionsInFormat, serviceImpl.GetPropertyTransactionsInFormat).Build();
+          .AddMethod(__Method_UploadPropertyTransactionsInFormat, serviceImpl.UploadPropertyTransactionsInFormat).Build();
     }
 
   }

--- a/proto/money/rpc/accounting_txn_svc.proto
+++ b/proto/money/rpc/accounting_txn_svc.proto
@@ -5,27 +5,20 @@ option csharp_namespace = "HOLMS.Types.Money.RPC";
 option go_package = "money/rpc";
 
 import "google/protobuf/empty.proto";
-import "google/protobuf/timestamp.proto";
 import "primitive/pb_inclusive_calendar_date_range.proto";
 import "crm/guests/guest_indicator.proto";
 import "money/accounting/accounting_transaction_export_format.proto";
 import "money/accounting/accounting_txn_export_status.proto";
 import "money/accounting/accounting_transaction_with_guest.proto";
-import "tenancy_config/indicators/property_indicator.proto";
 
 message AssignGuestOwnerToTxnReq {
 	.holms.types.money.accounting.AccountingTransactionWithGuest accounting_transaction_with_guest = 1;
 	.holms.types.crm.guests.GuestIndicator guest = 2;
 }
 
-message AccountTxnExportSvcGetPropertyTransactionsInFormatRequest {
+message AccountTxnExportSvcUploadPropertyTransactionsInFormatRequest {
 	.holms.types.money.accounting.AccountingTransactionExportFormat format = 1;
-	.holms.types.tenancy_config.indicators.PropertyIndicator property = 2;
 	.holms.types.primitive.PbInclusiveCalendarDateRange date_range = 3;
-}
-
-message AccountTxnExportSvcGetPropertyTransactionsInFormatResponse {
-	bytes exported_transactions = 1;
 }
 
 service AccountingTxnSvc {
@@ -35,9 +28,6 @@ service AccountingTxnSvc {
 	rpc GetExportJobStatus(google.protobuf.Empty)
 		returns (.holms.types.money.accounting.AccountingTxnExportStatus);
 
-	rpc UpdateLastExportRunTime(google.protobuf.Timestamp) 
+	rpc UploadPropertyTransactionsInFormat(AccountTxnExportSvcUploadPropertyTransactionsInFormatRequest)
 		returns (google.protobuf.Empty);
-
-	rpc GetPropertyTransactionsInFormat(AccountTxnExportSvcGetPropertyTransactionsInFormatRequest)
-		returns (AccountTxnExportSvcGetPropertyTransactionsInFormatResponse);
 }

--- a/proto/money/rpc/accounting_txn_svc.proto
+++ b/proto/money/rpc/accounting_txn_svc.proto
@@ -18,7 +18,9 @@ message AssignGuestOwnerToTxnReq {
 
 message AccountTxnExportSvcUploadPropertyTransactionsInFormatRequest {
 	.holms.types.money.accounting.AccountingTransactionExportFormat format = 1;
+	// .holms.types.tenancy_config.indicators.PropertyIndicator property = 2;
 	.holms.types.primitive.PbInclusiveCalendarDateRange date_range = 3;
+	bool update_last_run_date = 4;
 }
 
 service AccountingTxnSvc {


### PR DESCRIPTION
@eldavido PTAL

This is some cleanup on the IIF export interface. We no longer return the IIF string to the scheduler, because it's getting uploaded directly from the app server.

App server also will be handling tracking the last IIF export, with the option to ignore (used for manual export).