### PR TITLE
[#149940625] Fixes tag compatability

### DIFF
--- a/csharp/HOLMS.Platform/HOLMS.Platform/Support/ReservationTags/TaxExemptTag.cs
+++ b/csharp/HOLMS.Platform/HOLMS.Platform/Support/ReservationTags/TaxExemptTag.cs
@@ -10,7 +10,7 @@ namespace HOLMS.Platform.Support.ReservationTags {
         private string _taxExemptID;
 
         public TaxExemptTag(string [] tokens) {
-            if(tokens.Count() > 1) {
+            if(tokens.Count() == 3) {
                 _taxExemptCategory = tokens[1];
                 _taxExemptID = tokens[2];
             }
@@ -21,7 +21,7 @@ namespace HOLMS.Platform.Support.ReservationTags {
             _taxExemptCategory = taxExemptCategory.Replace(":", string.Empty);
             _taxExemptID = taxExemptID.Replace(":", string.Empty);
         }
-
+        
         public override bool IsPermanent {
             get {
                 return false;

--- a/csharp/HOLMS.Platform/HOLMS.Platform/Support/ReservationTags/TaxExemptTag.cs
+++ b/csharp/HOLMS.Platform/HOLMS.Platform/Support/ReservationTags/TaxExemptTag.cs
@@ -10,7 +10,10 @@ namespace HOLMS.Platform.Support.ReservationTags {
         private string _taxExemptID;
 
         public TaxExemptTag(string [] tokens) {
-            if(tokens.Count() == 3) {
+            // Token 0 is the primary descriptor tokens 1, 2 are optional tax exempt category
+            // and tax exempt ID. These fields are optional to be compatible with legacy tax exempt tags
+            // that are described by "te:"
+            if(tokens.Length == 3) {
                 _taxExemptCategory = tokens[1];
                 _taxExemptID = tokens[2];
             }


### PR DESCRIPTION
Old tax-exempt tags were arriving as "te:", causing string.Split() to
yield 2-element array with the second element as null.

Corrects the constructor to accomodate this.